### PR TITLE
Clean up warnings about implicitly overriden destructors in Clang 5.0.

### DIFF
--- a/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
+++ b/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
@@ -48,7 +48,7 @@ public:
   explicit DwarfReader(LibScopeView::ViewSpecification *spec)
       : LibScopeView::Reader(spec) {}
 
-  ~DwarfReader() {}
+  ~DwarfReader() override {}
 
   DwarfReader(const DwarfReader &) = delete;
   DwarfReader &operator=(const DwarfReader &) = delete;

--- a/DIVA/LibScopeView/src/Line.h
+++ b/DIVA/LibScopeView/src/Line.h
@@ -41,7 +41,7 @@ class Line : public Element {
 public:
   Line();
   Line(LevelType Lvl);
-  virtual ~Line();
+  virtual ~Line() override;
 
   Line &operator=(const Line &) = delete;
   Line(const Line &) = delete;

--- a/DIVA/LibScopeView/src/Object.h
+++ b/DIVA/LibScopeView/src/Object.h
@@ -347,7 +347,7 @@ class Element : public Object {
 public:
   Element();
   Element(LevelType Lvl);
-  virtual ~Element() {}
+  virtual ~Element() override {}
 
   Element &operator=(const Element &) = delete;
   Element(const Element &) = delete;

--- a/DIVA/LibScopeView/src/Scope.h
+++ b/DIVA/LibScopeView/src/Scope.h
@@ -46,7 +46,7 @@ class Scope : public Element {
 public:
   Scope();
   Scope(LevelType Lvl);
-  virtual ~Scope();
+  virtual ~Scope() override;
 
   Scope &operator=(const Scope &) = delete;
   Scope(const Scope &) = delete;
@@ -418,7 +418,7 @@ class ScopeAggregate : public Scope {
 public:
   ScopeAggregate();
   ScopeAggregate(LevelType Lvl);
-  virtual ~ScopeAggregate();
+  virtual ~ScopeAggregate() override;
 
   ScopeAggregate &operator=(const ScopeAggregate &) = delete;
   ScopeAggregate(const ScopeAggregate &) = delete;
@@ -446,7 +446,7 @@ class ScopeAlias : public Scope {
 public:
   ScopeAlias();
   ScopeAlias(LevelType Lvl);
-  virtual ~ScopeAlias();
+  virtual ~ScopeAlias() override;
 
   ScopeAlias &operator=(const ScopeAlias &) = delete;
   ScopeAlias(const ScopeAlias &) = delete;
@@ -465,7 +465,7 @@ class ScopeArray : public Scope {
 public:
   ScopeArray();
   ScopeArray(LevelType Lvl);
-  virtual ~ScopeArray();
+  virtual ~ScopeArray() override;
 
   ScopeArray &operator=(const ScopeArray &) = delete;
   ScopeArray(const ScopeArray &) = delete;
@@ -483,7 +483,7 @@ class ScopeCompileUnit : public Scope {
 public:
   ScopeCompileUnit();
   ScopeCompileUnit(LevelType Lvl);
-  virtual ~ScopeCompileUnit();
+  virtual ~ScopeCompileUnit() override;
 
   ScopeCompileUnit &operator=(const ScopeCompileUnit &) = delete;
   ScopeCompileUnit(const ScopeCompileUnit &) = delete;
@@ -508,7 +508,7 @@ class ScopeEnumeration : public Scope {
 public:
   ScopeEnumeration();
   ScopeEnumeration(LevelType Lvl);
-  virtual ~ScopeEnumeration();
+  virtual ~ScopeEnumeration() override;
 
   ScopeEnumeration &operator=(const ScopeEnumeration &) = delete;
   ScopeEnumeration(const ScopeEnumeration &) = delete;
@@ -533,7 +533,7 @@ class ScopeFunction : public Scope {
 public:
   ScopeFunction();
   ScopeFunction(LevelType Lvl);
-  virtual ~ScopeFunction();
+  virtual ~ScopeFunction() override;
 
   ScopeFunction &operator=(const ScopeFunction &) = delete;
   ScopeFunction(const ScopeFunction &) = delete;
@@ -578,7 +578,7 @@ class ScopeFunctionInlined : public ScopeFunction {
 public:
   ScopeFunctionInlined();
   ScopeFunctionInlined(LevelType Lvl);
-  virtual ~ScopeFunctionInlined();
+  virtual ~ScopeFunctionInlined() override;
 
   ScopeFunctionInlined &operator=(const ScopeFunctionInlined &) = delete;
   ScopeFunctionInlined(const ScopeFunctionInlined &) = delete;
@@ -619,7 +619,7 @@ class ScopeNamespace : public Scope {
 public:
   ScopeNamespace();
   ScopeNamespace(LevelType Lvl);
-  virtual ~ScopeNamespace();
+  virtual ~ScopeNamespace() override;
 
   ScopeNamespace &operator=(const ScopeNamespace &) = delete;
   ScopeNamespace(const ScopeNamespace &) = delete;
@@ -652,7 +652,7 @@ class ScopeTemplatePack : public Scope {
 public:
   ScopeTemplatePack();
   ScopeTemplatePack(LevelType Lvl);
-  virtual ~ScopeTemplatePack();
+  virtual ~ScopeTemplatePack() override;
 
   ScopeTemplatePack &operator=(const ScopeTemplatePack &) = delete;
   ScopeTemplatePack(const ScopeTemplatePack &) = delete;
@@ -671,7 +671,7 @@ class ScopeRoot : public Scope {
 public:
   ScopeRoot();
   ScopeRoot(LevelType Lvl);
-  virtual ~ScopeRoot();
+  virtual ~ScopeRoot() override;
 
   ScopeRoot &operator=(const ScopeRoot &) = delete;
   ScopeRoot(const ScopeRoot &) = delete;

--- a/DIVA/LibScopeView/src/ScopePrinter.h
+++ b/DIVA/LibScopeView/src/ScopePrinter.h
@@ -63,7 +63,7 @@ class ScopeRoot;
 class ScopePrinter : private ConstScopeVisitor {
 public:
   ScopePrinter() : OutputStream(nullptr) {}
-  virtual ~ScopePrinter() {}
+  virtual ~ScopePrinter() override {}
 
   /// \brief Print Obj to Output.
   void print(const Object *Obj, std::ostream &Output);

--- a/DIVA/LibScopeView/src/ScopeVisitor.h
+++ b/DIVA/LibScopeView/src/ScopeVisitor.h
@@ -58,7 +58,7 @@ protected:
 /// \brief A ScopeVisitor that traverses and visits const Objects.
 class ConstScopeVisitor : private ScopeVisitor {
 public:
-  virtual ~ConstScopeVisitor();
+  virtual ~ConstScopeVisitor() override;
 
   /// \brief Visit an object.
   void visit(const Object *Obj) {

--- a/DIVA/LibScopeView/src/Symbol.h
+++ b/DIVA/LibScopeView/src/Symbol.h
@@ -39,7 +39,7 @@ class Symbol : public Element {
 public:
   Symbol();
   Symbol(LevelType Lvl);
-  virtual ~Symbol();
+  virtual ~Symbol() override;
 
   Symbol &operator=(const Symbol &) = delete;
   Symbol(const Symbol &) = delete;

--- a/DIVA/LibScopeView/src/Type.h
+++ b/DIVA/LibScopeView/src/Type.h
@@ -38,7 +38,7 @@ class Type : public Element {
 public:
   Type();
   Type(LevelType Lvl);
-  virtual ~Type();
+  virtual ~Type() override;
 
   Type &operator=(const Type &) = delete;
   Type(const Type &) = delete;
@@ -240,7 +240,7 @@ class TypeDefinition : public Type {
 public:
   TypeDefinition();
   TypeDefinition(LevelType Lvl);
-  virtual ~TypeDefinition();
+  virtual ~TypeDefinition() override;
 
   TypeDefinition &operator=(const TypeDefinition &) = delete;
   TypeDefinition(const TypeDefinition &) = delete;
@@ -267,7 +267,7 @@ class TypeEnumerator : public Type {
 public:
   TypeEnumerator();
   TypeEnumerator(LevelType Lvl);
-  virtual ~TypeEnumerator();
+  virtual ~TypeEnumerator() override;
 
   TypeEnumerator &operator=(const TypeEnumerator &) = delete;
   TypeEnumerator(const TypeEnumerator &) = delete;
@@ -297,7 +297,7 @@ class TypeImport : public Type {
 public:
   TypeImport();
   TypeImport(LevelType Lvl);
-  virtual ~TypeImport();
+  virtual ~TypeImport() override;
 
   TypeImport &operator=(const TypeImport &) = delete;
   TypeImport(const TypeImport &) = delete;
@@ -335,7 +335,7 @@ class TypeParam : public Type {
 public:
   TypeParam();
   TypeParam(LevelType Lvl);
-  virtual ~TypeParam();
+  virtual ~TypeParam() override;
 
   TypeParam &operator=(const TypeParam &) = delete;
   TypeParam(const TypeParam &) = delete;
@@ -365,7 +365,7 @@ class TypeSubrange : public Type {
 public:
   TypeSubrange();
   TypeSubrange(LevelType Lvl);
-  virtual ~TypeSubrange();
+  virtual ~TypeSubrange() override;
 
   TypeSubrange &operator=(const TypeSubrange &) = delete;
   TypeSubrange(const TypeSubrange &) = delete;


### PR DESCRIPTION
With this patch, Diva builds with Clang 5.0 and Clang master (6.0 r313254)
The unit tests were clean on both Windows and Linux.