### PR TITLE
Add config files for CI on Travis and Appveyor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 DIVA/SystemTests/**/*cache*
 DIVA/UnitTests/testoutputs
 DIVA/UnitTests/TestOutputs
+# Ignore build directories
+DIVA/build*

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,117 @@
+language: C++
+
+matrix:
+  include:
+    - os: linux
+      compiler: gcc-5
+      addons:
+        apt:
+          sources: [ ubuntu-toolchain-r-test ]
+          packages:
+            - ninja-build
+            - cmake
+            - g++-5
+      env:
+        - CMAKE_BUILD_TYPE=DEBUG
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+    - os: linux
+      compiler: gcc-5
+      addons:
+        apt:
+          sources: [ ubuntu-toolchain-r-test ]
+          packages:
+            - ninja-build
+            - cmake
+            - g++-5
+      env:
+        - CMAKE_BUILD_TYPE=RELEASE
+        - MATRIX_EVAL="CC=gcc-5 && CXX=g++-5"
+
+    - os: linux
+      compiler: gcc-7
+      addons:
+        apt:
+          sources: [ ubuntu-toolchain-r-test ]
+          packages:
+            - ninja-build
+            - cmake
+            - g++-7
+      env:
+        - CMAKE_BUILD_TYPE=DEBUG
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+    - os: linux
+      compiler: gcc-7
+      addons:
+        apt:
+          sources: [ ubuntu-toolchain-r-test ]
+          packages:
+            - ninja-build
+            - cmake
+            - g++-7
+      env:
+        - CMAKE_BUILD_TYPE=RELEASE
+        - MATRIX_EVAL="CC=gcc-7 && CXX=g++-7"
+
+    - os: linux
+      compiler: clang-3.9
+      addons:
+        apt:
+          packages:
+            - ninja-build
+            - cmake
+            - libc++-dev
+      env:
+        - CMAKE_BUILD_TYPE=DEBUG
+        - MATRIX_EVAL="CC=clang && CXX=clang++ && CXXFLAGS=-stdlib=libc++"
+
+    - os: linux
+      compiler: clang-3.9
+      addons:
+        apt:
+          packages:
+            - ninja-build
+            - cmake
+            - libc++-dev
+      env:
+        - CMAKE_BUILD_TYPE=RELEASE
+        - MATRIX_EVAL="CC=clang && CXX=clang++ && CXXFLAGS=-stdlib=libc++"
+
+    - os: linux
+      compiler: clang-5.0
+      addons:
+        apt:
+          sources: [ 'llvm-toolchain-trusty-5.0' ]
+          packages:
+            - ninja-build
+            - cmake
+            - clang-5.0
+            - libc++-dev
+      env:
+        - CMAKE_BUILD_TYPE=DEBUG
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0 && CXXFLAGS=-stdlib=libc++"
+
+    - os: linux
+      compiler: clang-5.0
+      addons:
+        apt:
+          sources: [ 'llvm-toolchain-trusty-5.0' ]
+          packages:
+            - ninja-build
+            - cmake
+            - clang-5.0
+            - libc++-dev
+      env:
+        - CMAKE_BUILD_TYPE=RELEASE
+        - MATRIX_EVAL="CC=clang-5.0 && CXX=clang++-5.0 && CXXFLAGS=-stdlib=libc++"
+
+
+before_install:
+  - eval "${MATRIX_EVAL}"
+  - sudo pip install -r DIVA/SystemTests/requirements.txt
+
+script:
+  - cd DIVA
+  - cmake . -Bbuild -G Ninja -DCMAKE_CXX_FLAGS=$CXXFLAGS -DCMAKE_BUILD_TYPE=$CMAKE_BUILD_TYPE
+  - cmake --build build
+  - ./build/bin/unittests
+  - pytest SystemTests --divadir=build/bin

--- a/DIVA/CMakeLists.txt
+++ b/DIVA/CMakeLists.txt
@@ -3,11 +3,6 @@ get_filename_component(CMAKE_MODULE_PATH "CMake" ABSOLUTE)
 
 project(DIVA)
 
-if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "Clang" AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 3.8)
-    message(STATUS "Adding -stdlib=libc++")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -stdlib=libc++")
-endif ()
-
 set(gtest_force_shared_crt ON CACHE BOOL
     "Use shared (DLL) run-time lib even when Google Test is built as static lib.")
 add_subdirectory(ExternalDependencies/googletest)

--- a/DIVA/LibScopeView/src/Object.cpp
+++ b/DIVA/LibScopeView/src/Object.cpp
@@ -50,6 +50,7 @@
 
 #include <assert.h>
 #include <sstream>
+#include <cstring>
 
 using namespace LibScopeView;
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ On Linux you will need either GCC or Clang installed (other compilers might work
 cd DIVA
 mkdir build
 cd build
+# OPTIONAL: to build with libc++ rather than libstdc++
+export CXXFLAGS=-stdlib=libc++
 # You can change the build type to "Release"
 cmake .. -DCMAKE_BUILD_TYPE=Debug
 # For subsequent builds you only need to run this second cmake command again

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,37 @@
+image:
+  - Visual Studio 2015
+  - Visual Studio 2017
+
+configuration:
+  - Debug
+  - Release
+
+platform:
+  - x64
+
+init:
+  - cmd: cmake --version
+  - cmd: msbuild /version
+
+clone_folder: c:\projects\DIVA
+
+# scripts to run before build
+before_build:
+  - cmd: cd c:\projects\DIVA\DIVA
+  - cmd: if "%platform%"=="Win32" set CMAKE_GENERATOR_NAME=Visual Studio 14 2015
+  - cmd: if "%platform%"=="x64"   set CMAKE_GENERATOR_NAME=Visual Studio 14 2015 Win64
+  - cmd: cmake . -Bbuild -G "%CMAKE_GENERATOR_NAME%" -DCMAKE_BUILD_TYPE=%configuration%
+  - cmd: pip install -r SystemTests\requirements.txt
+
+build:
+  project: C:\projects\DIVA\DIVA\build\DIVA.sln
+  parallel: true
+  verbosity: quiet
+
+test_script:
+  - cmd: C:\projects\DIVA\DIVA\build\bin\%configuration%\unittests.exe --gtest_output=xml:unittests.xml
+  - cmd: pytest C:\projects\DIVA\DIVA\SystemTests --divadir=C:\projects\DIVA\DIVA\build\bin\%configuration% --junitxml=systemtests.xml
+
+after_test:
+  - ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\unittests.xml))
+  - ps: (new-object net.webclient).UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\systemtests.xml))


### PR DESCRIPTION
Plus two small changes to get it working with GCC and clang on Travis' old Ubuntu.

To set up TravisCI for Linux:
- Go to https://travis-ci.org/
- Login with your Github account
- Click the "+" next to "My Repositories" on the left
- Toggle SNSystems/DIVA to on

To set up Appveyor for Windows:
- Go to https://www.appveyor.com/
- Sign in with your Github account
- Click "New Project"
- Select DIVA and click "Add"