### PR TITLE
Seperate settings from reader

### DIFF
--- a/DIVA/Diva/src/main.cpp
+++ b/DIVA/Diva/src/main.cpp
@@ -47,7 +47,7 @@ typedef std::unique_ptr<LibScopeView::Reader> ReaderUPtr;
 ReaderUPtr createReader(const std::string &InputFilePath) {
   if (LibScopeView::isFileFormatElf(InputFilePath))
     return std::make_unique<ElfDwarfReader::DwarfReader>();
-  
+
   fatalError(LibScopeError::ErrorCode::ERR_INVALID_FILE, InputFilePath);
 }
 
@@ -72,11 +72,11 @@ int main(int argc, char *argv[]) {
     // Check that the file exists.
     if (!LibScopeView::doesFileExist(InputFilePath))
       fatalError(LibScopeError::ErrorCode::ERR_FILE_NOT_FOUND, InputFilePath);
-    
+
     Readers.push_back(createReader(InputFilePath));
     assert(Readers.back());
-    bool Result = Readers.back()->loadFile(InputFilePath,
-                                           Options.PrintingSettings);
+    bool Result =
+        Readers.back()->loadFile(InputFilePath, Options.PrintingSettings);
 
     if (!Result)
       // Currently the ElfDwarfReader will always call fatalError itself so we

--- a/DIVA/Diva/src/main.cpp
+++ b/DIVA/Diva/src/main.cpp
@@ -98,10 +98,10 @@ int main(int argc, char *argv[]) {
       // YAML_OUTPUT_VERSION_STR is defined by CMake.
       LibScopeView::ScopeYAMLPrinter YAMLPrinter(AReader->getInputFile(),
                                                  YAML_OUTPUT_VERSION_STR);
-      if (AReader->getPrintSettings().SplitOutput) {
+      if (Options.PrintingSettings.SplitOutput) {
         YAMLPrinter.print(
             static_cast<LibScopeView::ScopeRoot *>(AReader->getScopesRoot()),
-            AReader->getPrintSettings().OutputDirectory);
+            Options.PrintingSettings.OutputDirectory);
       } else {
         YAMLPrinter.print(AReader->getScopesRoot(), std::cout);
       }

--- a/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
+++ b/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
@@ -47,9 +47,7 @@ enum class DwarfAttrValueKind;
 
 class DwarfReader : public LibScopeView::Reader {
 public:
-  explicit DwarfReader(const LibScopeView::PrintSettings &PrintingSettings)
-      : LibScopeView::Reader(PrintingSettings) {}
-
+  DwarfReader() : LibScopeView::Reader() {}
   ~DwarfReader() override {}
 
   DwarfReader(const DwarfReader &) = delete;

--- a/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
+++ b/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
@@ -95,15 +95,15 @@ private:
 
   /// Get an attribute, but produce a warning an return an empty DwarfAttrValue
   /// if the value is not the ExpectedKind or ValueKind::Empty.
-  DwarfAttrValue
-  getAttrExpectingKind(const DwarfDie &Die, const Dwarf_Half Attr,
-                       const DwarfAttrValueKind ExpectedKind);
+  DwarfAttrValue getAttrExpectingKind(const DwarfDie &Die,
+                                      const Dwarf_Half Attr,
+                                      const DwarfAttrValueKind ExpectedKind);
 
   /// Get an attribute, but produce a warning an return an empty DwarfAttrValue
   /// if the value is not in the ExpectedKinds or ValueKind::Empty.
-  DwarfAttrValue getAttrExpectingKinds(
-      const DwarfDie &Die, const Dwarf_Half Attr,
-      const std::set<DwarfAttrValueKind> &ExpectedKinds);
+  DwarfAttrValue
+  getAttrExpectingKinds(const DwarfDie &Die, const Dwarf_Half Attr,
+                        const std::set<DwarfAttrValueKind> &ExpectedKinds);
 
   /// Return true if Die has Attr and the value is a flag set to true.
   bool attrIsTrueFlag(const DwarfDie &Die, const Dwarf_Half Attr);

--- a/DIVA/LibScopeView/src/Line.cpp
+++ b/DIVA/LibScopeView/src/Line.cpp
@@ -105,30 +105,31 @@ void Line::dump() {
 }
 
 void Line::dumpExtra() {
-  GlobalPrintContext->print("%s\n", getAsText().c_str());
+  GlobalPrintContext->print("%s\n",
+                            getAsText(getReader()->getPrintSettings()).c_str());
 }
 
-std::string Line::getAsText() const {
+std::string Line::getAsText(const PrintSettings &Settings) const {
   std::stringstream Result;
   Result << '{' << getKindAsString() << '}';
-  if (getReader()->getPrintSettings().ShowCodelineAttributes) {
+  if (Settings.ShowCodelineAttributes) {
     if (getIsNewStatement()) {
-      Result << '\n' << getAttributeInfoAsText(KindNewStatement);
+      Result << '\n' << getAttributeInfoAsText(KindNewStatement, Settings);
     }
     if (getIsPrologueEnd()) {
-      Result << '\n' << getAttributeInfoAsText(KindPrologueEnd);
+      Result << '\n' << getAttributeInfoAsText(KindPrologueEnd, Settings);
     }
     if (getIsLineEndSequence()) {
-      Result << '\n' << getAttributeInfoAsText(KindEndSequence);
+      Result << '\n' << getAttributeInfoAsText(KindEndSequence, Settings);
     }
     if (getIsNewBasicBlock()) {
-      Result << '\n' << getAttributeInfoAsText(KindBasicBlock);
+      Result << '\n' << getAttributeInfoAsText(KindBasicBlock, Settings);
     }
     if (getHasDiscriminator()) {
-      Result << '\n' << getAttributeInfoAsText(KindDiscriminator);
+      Result << '\n' << getAttributeInfoAsText(KindDiscriminator, Settings);
     }
     if (getIsEpilogueBegin()) {
-      Result << '\n' << getAttributeInfoAsText(KindEpilogueBegin);
+      Result << '\n' << getAttributeInfoAsText(KindEpilogueBegin, Settings);
     }
   }
   return Result.str();

--- a/DIVA/LibScopeView/src/Line.cpp
+++ b/DIVA/LibScopeView/src/Line.cpp
@@ -36,8 +36,7 @@
 
 using namespace LibScopeView;
 
-Line::Line(LevelType Lvl)
-    : Element(Lvl), Discriminator(0) {
+Line::Line(LevelType Lvl) : Element(Lvl), Discriminator(0) {
   setIsLine();
 
   Line::setTag();

--- a/DIVA/LibScopeView/src/Line.cpp
+++ b/DIVA/LibScopeView/src/Line.cpp
@@ -91,22 +91,21 @@ std::string Line::getLineNumberAsStringStripped() {
   return trim(number);
 }
 
-void Line::dump() {
-  if (getReader()->getPrintSettings().printObject(*this)) {
+void Line::dump(const PrintSettings &Settings) {
+  if (Settings.printObject(*this)) {
     // Object Summary Table.
     getReader()->incrementPrinted(this);
 
     // Common Object Data.
-    Element::dump();
+    Element::dump(Settings);
 
     // Specific Object Data.
-    dumpExtra();
+    dumpExtra(Settings);
   }
 }
 
-void Line::dumpExtra() {
-  GlobalPrintContext->print("%s\n",
-                            getAsText(getReader()->getPrintSettings()).c_str());
+void Line::dumpExtra(const PrintSettings &Settings) {
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
 std::string Line::getAsText(const PrintSettings &Settings) const {

--- a/DIVA/LibScopeView/src/Line.h
+++ b/DIVA/LibScopeView/src/Line.h
@@ -144,7 +144,7 @@ public:
   virtual void dumpExtra();
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 

--- a/DIVA/LibScopeView/src/Line.h
+++ b/DIVA/LibScopeView/src/Line.h
@@ -140,8 +140,8 @@ public:
   std::string getLineNumberAsStringStripped() override;
 
 public:
-  void dump() override;
-  virtual void dumpExtra();
+  void dump(const PrintSettings &Settings) override;
+  virtual void dumpExtra(const PrintSettings &Settings);
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;

--- a/DIVA/LibScopeView/src/Object.cpp
+++ b/DIVA/LibScopeView/src/Object.cpp
@@ -236,7 +236,8 @@ bool Object::referenceMatch(const Object *Obj) const {
   return true;
 }
 
-bool Object::setFullName(Type *BaseType, Scope *BaseScope, Scope *SpecScope,
+bool Object::setFullName(const PrintSettings &Settings, Type *BaseType,
+                         Scope *BaseScope, Scope *SpecScope,
                          const char *BaseText) {
   // In the case of scopes that have been updated using the specification
   // or abstract_origin attributes, the name already contain some patterns,
@@ -299,7 +300,7 @@ bool Object::setFullName(Type *BaseType, Scope *BaseScope, Scope *SpecScope,
     //                  DW_AT_type <0x0000003f>
     //   <0x0000003f> DW_TAG_pointer_type
     // For that case, we can emit the 'void' type.
-    if (!BaseType && !getType() && getReader()->getPrintSettings().ShowVoid)
+    if (!BaseType && !getType() && Settings.ShowVoid)
       ParentTypename = "void";
     break;
   case DW_TAG_ptr_to_member_type:
@@ -514,9 +515,8 @@ std::string Object::getAttributesAsText(const PrintSettings &Settings) {
   return Attributes;
 }
 
-void Object::printAttributes() {
-  GlobalPrintContext->print(
-      "%s", getAttributesAsText(getReader()->getPrintSettings()).c_str());
+void Object::printAttributes(const PrintSettings &Settings) {
+  GlobalPrintContext->print("%s", getAttributesAsText(Settings).c_str());
 }
 
 // Record the last seen filename index. It is reset after the object that
@@ -544,22 +544,22 @@ void Object::printFileIndex() {
   }
 }
 
-void Object::dump() {
+void Object::dump(const PrintSettings &Settings) {
   // Print the File ID if needed.
   if (getFileNameIndex())
     printFileIndex();
 
   // Print Debug Data (tag, offset, etc).
-  printAttributes();
+  printAttributes(Settings);
 
   // Print the line and any discriminator.
-  GlobalPrintContext->print(
-      " %5s %s ", getLineNumberAsString(),
-      getIndentString(getReader()->getPrintSettings()).c_str());
+  GlobalPrintContext->print(" %5s %s ", getLineNumberAsString(),
+                            getIndentString(Settings).c_str());
 }
 
-void Object::print(bool /*SplitCU*/, bool /*Match*/, bool /*IsNull*/) {
-  dump();
+void Object::print(bool /*SplitCU*/, bool /*Match*/, bool /*IsNull*/,
+                   const PrintSettings &Settings) {
+  dump(Settings);
 }
 
 std::string

--- a/DIVA/LibScopeView/src/Object.cpp
+++ b/DIVA/LibScopeView/src/Object.cpp
@@ -49,8 +49,8 @@
 #endif
 
 #include <assert.h>
-#include <sstream>
 #include <cstring>
+#include <sstream>
 
 using namespace LibScopeView;
 
@@ -135,8 +135,8 @@ const char *Object::getDieOffsetAsString(const PrintSettings &Settings) const {
   return Str;
 }
 
-const char *Object::getTypeDieOffsetAsString(
-    const PrintSettings &Settings) const {
+const char *
+Object::getTypeDieOffsetAsString(const PrintSettings &Settings) const {
   const char *Str = "";
   if (Settings.ShowDWARFOffset) {
     Str = OffsetAsString(getType() ? getType()->getDieOffset() : 0);
@@ -191,9 +191,7 @@ const char *Object::getReferenceAsString(uint64_t LnNumber, bool Spaces) const {
 }
 
 const char *Object::getTypeAsString(const PrintSettings &Settings) const {
-  return getHasType()
-             ? (getTypeName())
-             : (Settings.ShowVoid ? "void" : "");
+  return getHasType() ? (getTypeName()) : (Settings.ShowVoid ? "void" : "");
 }
 
 void Object::resolveQualifiedName(const Scope *ExplicitParent) {
@@ -648,9 +646,7 @@ std::string Object::getCommonYAML() const {
 //===----------------------------------------------------------------------===//
 // Class to represent the basic data for an object.
 //===----------------------------------------------------------------------===//
-Element::Element(LevelType level) : Object(level) {
-  CommonConstructor();
-}
+Element::Element(LevelType level) : Object(level) { CommonConstructor(); }
 
 Element::Element() : Object() { CommonConstructor(); }
 

--- a/DIVA/LibScopeView/src/Object.h
+++ b/DIVA/LibScopeView/src/Object.h
@@ -49,6 +49,7 @@
 namespace LibScopeView {
 
 class Object;
+class PrintSettings;
 class Scope;
 class Type;
 
@@ -262,7 +263,7 @@ public:
   /// \brief The level where this object is located.
   LevelType getLevel() const { return Level; }
   void setLevel(LevelType Lvl) { Level = Lvl; }
-  std::string getIndentString() const;
+  std::string getIndentString(const PrintSettings &Settings) const;
 
   bool referenceMatch(const Object *Obj) const;
 
@@ -274,9 +275,9 @@ public:
   virtual bool getIsCompileUnit() const { return false; }
 
   // Get some attributes as string.
-  const char *getDieOffsetAsString() const;
-  const char *getTypeDieOffsetAsString() const;
-  const char *getTypeAsString() const;
+  const char *getDieOffsetAsString(const PrintSettings &Settings) const;
+  const char *getTypeDieOffsetAsString(const PrintSettings &Settings) const;
+  const char *getTypeAsString(const PrintSettings &Settings) const;
 
   /// \brief String to be used for objects with no line number.
   virtual const char *getNoLineString() const;
@@ -306,7 +307,7 @@ public:
   virtual void printAttributes();
 
   /// \brief Get the attributes associated with the object as string.
-  std::string getAttributesAsText();
+  std::string getAttributesAsText(const PrintSettings &Settings);
 
 public:
   static size_t getIndentationSize() { return IndentationSize; }
@@ -320,13 +321,14 @@ public:
   /// \brief Should this object be printed under children?
   virtual bool getIsPrintedAsObject() const { return true; }
   /// \brief Returns a text representation of this DIVA Object.
-  virtual std::string getAsText() const = 0;
+  virtual std::string getAsText(const PrintSettings &Settings) const = 0;
   /// \brief Returns a YAML representation of this DIVA Object.
   virtual std::string getAsYAML() const = 0;
 
 protected:
   /// \brief Returns a text representation of attribute information.
-  std::string getAttributeInfoAsText(const std::string &AttributeText) const;
+  std::string getAttributeInfoAsText(const std::string &AttributeText,
+                                     const PrintSettings &Settings) const;
   /// \brief Returns the common YAML information for this object.
   std::string getCommonYAML() const;
 

--- a/DIVA/LibScopeView/src/Object.h
+++ b/DIVA/LibScopeView/src/Object.h
@@ -300,11 +300,12 @@ public:
   virtual void setType(Object *Obj) = 0;
 
   /// \brief Generate the full name for the object.
-  bool setFullName(Type *BaseType, Scope *BaseScope, Scope *SpecScope,
+  bool setFullName(const PrintSettings &Settings, Type *BaseType,
+                   Scope *BaseScope, Scope *SpecScope,
                    const char *BaseText = nullptr);
 
 public:
-  virtual void printAttributes();
+  virtual void printAttributes(const PrintSettings &Settings);
 
   /// \brief Get the attributes associated with the object as string.
   std::string getAttributesAsText(const PrintSettings &Settings);
@@ -313,8 +314,9 @@ public:
   static size_t getIndentationSize() { return IndentationSize; }
 
 public:
-  virtual void dump();
-  virtual void print(bool SplitCU, bool Match, bool IsNull);
+  virtual void dump(const PrintSettings &Settings);
+  virtual void print(bool SplitCU, bool Match, bool IsNull,
+                     const PrintSettings &Settings);
   virtual uint32_t getTag() const;
   virtual void setTag();
 

--- a/DIVA/LibScopeView/src/PrintSettings.h
+++ b/DIVA/LibScopeView/src/PrintSettings.h
@@ -30,6 +30,8 @@
 #ifndef SCOPEVIEW_PRINTSETTINGS_H
 #define SCOPEVIEW_PRINTSETTINGS_H
 
+#include "Sort.h"
+
 #include <regex>
 #include <set>
 #include <vector>
@@ -37,8 +39,6 @@
 namespace LibScopeView {
 
 class Object;
-
-enum class SortingKey { LINE, OFFSET, NAME };
 
 class PrintSettings {
 public:

--- a/DIVA/LibScopeView/src/Reader.cpp
+++ b/DIVA/LibScopeView/src/Reader.cpp
@@ -146,6 +146,10 @@ namespace {
 // Visitor that creates all the full type names once the CU tree has been
 // created.
 class NameResolver : public ScopeVisitor {
+public:
+  NameResolver(const PrintSettings &PrintingSettings)
+      : Settings(PrintingSettings) {}
+
 private:
   void visitImpl(Object *Obj) override {
     resolve(Obj);
@@ -185,7 +189,7 @@ private:
       resolve(Func->getType());
 
     std::stringstream ResolvedName;
-    ResolvedName << Func->getTypeAsString() << " (*)(";
+    ResolvedName << Func->getTypeAsString(Settings) << " (*)(";
 
     // Add the parameters.
     bool First = true;
@@ -232,6 +236,7 @@ private:
     Array->setName(ResolvedName.c_str());
   }
 
+  const PrintSettings &Settings;
   std::unordered_set<Object *> AlreadyResolved;
 };
 
@@ -318,7 +323,7 @@ private:
 void Reader::postCreationActions() {
   assert(Scopes);
 
-  NameResolver().visit(Scopes);
+  NameResolver(Settings).visit(Scopes);
   ReferenceAttributeResolver().visit(Scopes);
   TreeResolver(*this).visit(Scopes);
 

--- a/DIVA/LibScopeView/src/Reader.cpp
+++ b/DIVA/LibScopeView/src/Reader.cpp
@@ -50,40 +50,25 @@ Reader *GlobalReader = nullptr;
 Reader *LibScopeView::getReader() { return GlobalReader; }
 void LibScopeView::setReader(Reader *Rdr) { GlobalReader = Rdr; }
 
-bool Reader::executeActions() {
-  destroyScopes();
-
-  // Record current Reader, so it will be available to places where is hard
-  // to access it.
-  setReader(this);
-
-  // Delegate the scope tree creation to the respective reader.
-  if (!createScopes())
-    return false;
-
-  postCreationActions();
-  return true;
-}
-
 // Print summary details for the Scopes Tree.
-void Reader::printSummary() {
+void Reader::printSummary(const PrintSettings &Settings) {
   if (!PrintedHeader) {
     getScopesRoot()->dump(Settings);
   }
   TheSummaryTable.getPrintedSummaryTable(std::cout);
 }
 
-void Reader::print() {
+void Reader::print(const PrintSettings &Settings) {
   // If doing any search (--filter), do not do any scope tree printing.
   if (!Settings.Filters.empty() || !Settings.FilterAnys.empty()) {
-    printObjects();
+    printObjects(Settings);
   } else {
-    printScopes();
+    printScopes(Settings);
   }
   std::cout << "\n";
 }
 
-void Reader::printObjects() {
+void Reader::printObjects(const PrintSettings &Settings) {
   if (getPrintObjects() && ViewMatchedObjects.size()) {
     // Get the sorting callback function.
     SortFunction SortFunc = getSortFunction(Settings.SortKey);
@@ -99,10 +84,10 @@ void Reader::printObjects() {
   }
 
   if (Settings.ShowSummary)
-    printSummary();
+    printSummary(Settings);
 }
 
-void Reader::printScopes() {
+void Reader::printScopes(const PrintSettings &Settings) {
   bool DoPrint = getPrintObjects();
   if (DoPrint) {
     // Propagate any matching information into the scopes tree.
@@ -132,12 +117,24 @@ void Reader::printScopes() {
   }
 
   if (Settings.ShowSummary)
-    printSummary();
+    printSummary(Settings);
 }
 
-bool Reader::loadFile(const std::string &FileName) {
+bool Reader::loadFile(const std::string &FileName,
+                      const PrintSettings &Settings) {
+  destroyScopes();
   InputFile = FileName;
-  return executeActions();
+
+  // Record current Reader, so it will be available to places where is hard
+  // to access it.
+  setReader(this);
+
+  // Delegate the scope tree creation to the respective reader.
+  if (!createScopes())
+    return false;
+
+  postCreationActions(Settings);
+  return true;
 }
 
 // Visitors for post-creation actions.
@@ -294,8 +291,8 @@ private:
 // it has been created and the type names and references have been resolved.
 class TreeResolver : public ScopeVisitor {
 public:
-  TreeResolver(Reader &Reader)
-      : ReaderInstance(Reader) {}
+  TreeResolver(Reader &Reader, const PrintSettings &PrintingSettings)
+      : ReaderInstance(Reader), Settings(PrintingSettings) {}
 
 private:
   void visitImpl(Object *Obj) override {
@@ -305,9 +302,9 @@ private:
 
     // Resolve any filters.
     // TODO: Filters should be evaluated while printing.
-    ReaderInstance.resolveFilterPatternMatch(Obj);
+    ReaderInstance.resolveFilterPatternMatch(Obj, Settings);
     if (auto Scp = dynamic_cast<Scope *>(Obj))
-      ReaderInstance.resolveTreePatternMatch(Scp);
+      ReaderInstance.resolveTreePatternMatch(Scp, Settings);
 
     // If the parent is global then mark this as global.
     if (Obj->getParent() && Obj->getParent()->getIsGlobalReference())
@@ -317,15 +314,16 @@ private:
   }
 
   Reader &ReaderInstance;
+  const PrintSettings &Settings;
 };
 } // namespace
 
-void Reader::postCreationActions() {
+void Reader::postCreationActions(const PrintSettings &Settings) {
   assert(Scopes);
 
   NameResolver(Settings).visit(Scopes);
   ReferenceAttributeResolver().visit(Scopes);
-  TreeResolver(*this).visit(Scopes);
+  TreeResolver(*this, Settings).visit(Scopes);
 
   Scopes->sortScopes(Settings.SortKey);
 }
@@ -340,20 +338,23 @@ void Reader::propagatePatternMatch() {
                       /*down=*/true);
 }
 
-void Reader::resolveTreePatternMatch(Scope *Scp) {
+void Reader::resolveTreePatternMatch(Scope *Scp,
+                                     const PrintSettings &Settings) {
   if (Scp->isNamed() &&
       Settings.matchesWithChildrenFilterPattern(Scp->getName())) {
     ViewMatchedScopes.push_back(Scp);
   }
 }
 
-void Reader::resolveFilterPatternMatch(Object *Object) {
+void Reader::resolveFilterPatternMatch(Object *Object,
+                                       const PrintSettings &Settings) {
   if (Object->isNamed() && Settings.matchesFilterPattern(Object->getName())) {
     ViewMatchedObjects.push_back(Object);
   }
 }
 
-void Reader::resolveFilterPatternMatch(Line *Line) {
+void Reader::resolveFilterPatternMatch(Line *Line,
+                                       const PrintSettings &Settings) {
   if (Settings.matchesFilterPattern(
       trim(Line->getLineNumberAsString()).c_str())) {
     ViewMatchedObjects.push_back(Line);

--- a/DIVA/LibScopeView/src/Reader.cpp
+++ b/DIVA/LibScopeView/src/Reader.cpp
@@ -68,7 +68,7 @@ bool Reader::executeActions() {
 // Print summary details for the Scopes Tree.
 void Reader::printSummary() {
   if (!PrintedHeader) {
-    getScopesRoot()->dump();
+    getScopesRoot()->dump(Settings);
   }
   TheSummaryTable.getPrintedSummaryTable(std::cout);
 }
@@ -86,16 +86,16 @@ void Reader::print() {
 void Reader::printObjects() {
   if (getPrintObjects() && ViewMatchedObjects.size()) {
     // Get the sorting callback function.
-    SortFunction SortFunc = getSortFunction();
+    SortFunction SortFunc = getSortFunction(Settings.SortKey);
     if (SortFunc) {
       std::sort(ViewMatchedObjects.begin(), ViewMatchedObjects.end(), SortFunc);
     }
 
-    getScopesRoot()->dump();
+    getScopesRoot()->dump(Settings);
     PrintedHeader = true;
 
     for (Object *Matched : ViewMatchedObjects)
-      Matched->dump();
+      Matched->dump(Settings);
   }
 
   if (Settings.ShowSummary)
@@ -128,7 +128,7 @@ void Reader::printScopes() {
     // We do a normal print, using the standard settings.
     bool Match = (!Settings.WithChildrenFilters.empty() ||
                   !Settings.WithChildrenFilterAnys.empty());
-    Scp->print(DoSplit, Match, DoPrint);
+    Scp->print(DoSplit, Match, DoPrint, Settings);
   }
 
   if (Settings.ShowSummary)
@@ -212,7 +212,7 @@ private:
     if (Ty->getType())
       resolve(Ty->getType());
 
-    bool Ret = Ty->setFullName();
+    bool Ret = Ty->setFullName(Settings);
     // setFullName keys off DWARF tags and will return false if it doesn't
     // recognise the tag.
     assert(Ret && "Unrecognised DWARF Tag in Object::setFullName");
@@ -327,7 +327,7 @@ void Reader::postCreationActions() {
   ReferenceAttributeResolver().visit(Scopes);
   TreeResolver(*this).visit(Scopes);
 
-  Scopes->sortScopes();
+  Scopes->sortScopes(Settings.SortKey);
 }
 
 void Reader::propagatePatternMatch() {

--- a/DIVA/LibScopeView/src/Reader.cpp
+++ b/DIVA/LibScopeView/src/Reader.cpp
@@ -167,8 +167,7 @@ private:
     if (auto ObjScope = dynamic_cast<Scope *>(Obj)) {
       // Resolve function pointer names.
       if (ObjScope->getIsSubroutineType()) {
-        resolveFunctionPointerName(
-            dynamic_cast<ScopeFunction *>(Obj));
+        resolveFunctionPointerName(dynamic_cast<ScopeFunction *>(Obj));
         return;
       }
 
@@ -356,7 +355,7 @@ void Reader::resolveFilterPatternMatch(Object *Object,
 void Reader::resolveFilterPatternMatch(Line *Line,
                                        const PrintSettings &Settings) {
   if (Settings.matchesFilterPattern(
-      trim(Line->getLineNumberAsString()).c_str())) {
+          trim(Line->getLineNumberAsString()).c_str())) {
     ViewMatchedObjects.push_back(Line);
   }
 }

--- a/DIVA/LibScopeView/src/Reader.h
+++ b/DIVA/LibScopeView/src/Reader.h
@@ -43,11 +43,8 @@ class Reader {
 public:
   Reader() : Scopes(nullptr), PrintedHeader(false) {}
 
-  Reader(const PrintSettings &PrintingSettings)
-    : Scopes(nullptr), PrintedHeader(false), Settings(PrintingSettings) {}
-
-  bool loadFile(const std::string &FileName);
-  void print();
+  bool loadFile(const std::string &FileName, const PrintSettings &Settings);
+  void print(const PrintSettings &Settings);
 
   virtual ~Reader() { delete Scopes; }
 
@@ -57,7 +54,7 @@ private:
   /// \brief Implements the creation of the tree from a file.
   virtual bool createScopes() { return false; }
 
-  void postCreationActions();
+  void postCreationActions(const PrintSettings &Settings);
 
   void destroyScopes() {
     delete Scopes;
@@ -72,8 +69,6 @@ protected:
 
 private:
   std::string InputFile;
-  
-  PrintSettings Settings;
   
   // Summary table member used with --show-summary.
   SummaryTable TheSummaryTable;
@@ -102,15 +97,15 @@ protected:
   MatchedObjects ViewMatchedObjects;
 
 protected:
-  virtual void printObjects();
-  virtual void printScopes();
-  virtual void printSummary();
+  virtual void printObjects(const PrintSettings &Settings);
+  virtual void printScopes(const PrintSettings &Settings);
+  virtual void printSummary(const PrintSettings &Settings);
 
 public:
   void propagatePatternMatch();
-  void resolveTreePatternMatch(Scope *scope);
-  void resolveFilterPatternMatch(Object *object);
-  void resolveFilterPatternMatch(Line *line);
+  void resolveTreePatternMatch(Scope *scope, const PrintSettings &Settings);
+  void resolveFilterPatternMatch(Object *object, const PrintSettings &Settings);
+  void resolveFilterPatternMatch(Line *line, const PrintSettings &Settings);
 
 public:
   std::string getInputFile() const { return InputFile; }
@@ -120,9 +115,6 @@ public:
 
   // Access to the scopes root.
   Scope *getScopesRoot() const { return Scopes; }
-
-  // Execute the required actions on the reader.
-  bool executeActions();
 };
 
 /// \brief Get the current Reader.

--- a/DIVA/LibScopeView/src/Reader.h
+++ b/DIVA/LibScopeView/src/Reader.h
@@ -69,7 +69,7 @@ protected:
 
 private:
   std::string InputFile;
-  
+
   // Summary table member used with --show-summary.
   SummaryTable TheSummaryTable;
 

--- a/DIVA/LibScopeView/src/Reader.h
+++ b/DIVA/LibScopeView/src/Reader.h
@@ -113,10 +113,6 @@ public:
   void resolveFilterPatternMatch(Line *line);
 
 public:
-  // Access to settings.
-  PrintSettings &getPrintSettings() { return Settings; }
-  const PrintSettings &getPrintSettings() const { return Settings; }
-
   std::string getInputFile() const { return InputFile; }
 
   // Shortcut for any printing.

--- a/DIVA/LibScopeView/src/Scope.cpp
+++ b/DIVA/LibScopeView/src/Scope.cpp
@@ -474,8 +474,7 @@ std::string Scope::getAsYAML() const {
   return "";
 }
 
-ScopeAggregate::ScopeAggregate(LevelType Lvl)
-    : Scope(Lvl) {
+ScopeAggregate::ScopeAggregate(LevelType Lvl) : Scope(Lvl) {
   Reference = nullptr;
 }
 
@@ -568,8 +567,7 @@ std::string ScopeArray::getAsText(const PrintSettings &Settings) const {
   return Result.str();
 }
 
-ScopeCompileUnit::ScopeCompileUnit(LevelType Lvl)
-    : Scope(Lvl) {}
+ScopeCompileUnit::ScopeCompileUnit(LevelType Lvl) : Scope(Lvl) {}
 
 ScopeCompileUnit::ScopeCompileUnit() : Scope() {}
 
@@ -614,8 +612,7 @@ ScopeEnumeration::~ScopeEnumeration() {}
 
 void ScopeEnumeration::dumpExtra(const PrintSettings &Settings) {
   // Print the full type name.
-  GlobalPrintContext->print("%s\n",
-                            getAsText(Settings).c_str());
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
 std::string ScopeEnumeration::getAsText(const PrintSettings &) const {
@@ -661,8 +658,7 @@ std::string ScopeEnumeration::getAsYAML() const {
 }
 
 ScopeFunction::ScopeFunction(LevelType Lvl)
-    : Scope(Lvl), IsStatic(false), DeclaredInline(false),
-      IsDeclaration(false) {
+    : Scope(Lvl), IsStatic(false), DeclaredInline(false), IsDeclaration(false) {
   Reference = nullptr;
 }
 
@@ -778,8 +774,7 @@ ScopeFunctionInlined::ScopeFunctionInlined()
 
 ScopeFunctionInlined::~ScopeFunctionInlined() {}
 
-ScopeNamespace::ScopeNamespace(LevelType Lvl)
-    : Scope(Lvl) {
+ScopeNamespace::ScopeNamespace(LevelType Lvl) : Scope(Lvl) {
   Reference = nullptr;
 }
 
@@ -805,8 +800,7 @@ std::string ScopeNamespace::getAsYAML() const {
   return getCommonYAML() + std::string("\nattributes: {}");
 }
 
-ScopeTemplatePack::ScopeTemplatePack(LevelType Lvl)
-    : Scope(Lvl) {}
+ScopeTemplatePack::ScopeTemplatePack(LevelType Lvl) : Scope(Lvl) {}
 
 ScopeTemplatePack::ScopeTemplatePack() : Scope() {}
 

--- a/DIVA/LibScopeView/src/Scope.h
+++ b/DIVA/LibScopeView/src/Scope.h
@@ -297,14 +297,10 @@ public:
 
 public:
   /// \brief Gets the child symbol at the specified index.
-  Symbol *getSymbolAt(size_t Index) const {
-    return TheSymbols.at(Index);
-  }
+  Symbol *getSymbolAt(size_t Index) const { return TheSymbols.at(Index); }
 
   /// \brief Gets the child scope at the specified index.
-  Scope *getScopeAt(size_t Index) const {
-    return TheScopes.at(Index);
-  }
+  Scope *getScopeAt(size_t Index) const { return TheScopes.at(Index); }
 
 public:
   const std::vector<Object *> &getChildren() const { return Children; }
@@ -318,9 +314,7 @@ public:
   const std::vector<Type *> &getTypes() const { return TheTypes; }
 
   /// \brief Get the number of children.
-  size_t getChildrenCount() const {
-    return getChildren().size();
-  }
+  size_t getChildrenCount() const { return getChildren().size(); }
 
   /// \brief Get the number of lines.
   size_t getLineCount() const { return getLines().size(); }

--- a/DIVA/LibScopeView/src/Scope.h
+++ b/DIVA/LibScopeView/src/Scope.h
@@ -344,12 +344,13 @@ public:
   void traverse(ScopeGetFunction GetFunc, ScopeSetFunction SetFunc, bool down);
 
   /// \brief Navigate down the current scope and perform the callback.
-  void print(bool SplitCU, bool Match, bool IsNull) override;
+  void print(bool SplitCU, bool Match, bool IsNull,
+             const PrintSettings &Settings) override;
 
   const char *resolveName();
 
-  void sortScopes();
-  void sortCompileUnits();
+  void sortScopes(const SortingKey &SortKey);
+  void sortCompileUnits(const SortingKey &SortKey);
 
   // bring parent method getQualifiedName into scope.
   using Element::getQualifiedName;
@@ -377,12 +378,13 @@ protected:
 
 public:
   /// \brief Decide if the object will be printed.
-  bool resolvePrinting();
+  bool resolvePrinting(const PrintSettings &Settings);
 
 public:
-  void dump() override;
-  virtual void dumpExtra();
-  virtual bool dump(bool DoHeader, const char *Header);
+  void dump(const PrintSettings &Settings) override;
+  virtual void dumpExtra(const PrintSettings &Settings);
+  virtual bool dump(bool DoHeader, const char *Header,
+                    const PrintSettings &Settings);
   virtual bool dumpAllowed() { return false; }
 
   /// \brief Returns a text representation of this DIVA Object.
@@ -438,7 +440,7 @@ public:
   ScopeAlias(const ScopeAlias &) = delete;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;
@@ -457,7 +459,7 @@ public:
   ScopeArray(const ScopeArray &) = delete;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   bool getIsPrintedAsObject() const override { return false; }
   /// \brief Returns a text representation of this DIVA Object.
@@ -478,8 +480,8 @@ public:
   void setName(const char *Name) override;
 
 public:
-  void dump() override;
-  void dumpExtra() override;
+  void dump(const PrintSettings &Settings) override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;
@@ -500,7 +502,7 @@ public:
   ScopeEnumeration(const ScopeEnumeration &) = delete;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;
@@ -551,7 +553,7 @@ public:
   void setIsDeclaration() { IsDeclaration = true; }
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;
@@ -623,7 +625,7 @@ public:
   }
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;
@@ -644,7 +646,7 @@ public:
   ScopeTemplatePack(const ScopeTemplatePack &) = delete;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;
@@ -666,8 +668,8 @@ public:
   void setName(const char *Name) override;
 
 public:
-  void dump() override;
-  void dumpExtra() override;
+  void dump(const PrintSettings &Settings) override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   bool dumpAllowed() override { return true; }
 

--- a/DIVA/LibScopeView/src/Scope.h
+++ b/DIVA/LibScopeView/src/Scope.h
@@ -386,7 +386,7 @@ public:
   virtual bool dumpAllowed() { return false; }
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 
@@ -422,7 +422,7 @@ public:
 
 public:
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -441,7 +441,7 @@ public:
   void dumpExtra() override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -461,7 +461,7 @@ public:
 
   bool getIsPrintedAsObject() const override { return false; }
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
 };
 
 /// \brief Class to represent a DWARF Compilation Unit (CU) object.
@@ -482,7 +482,7 @@ public:
   void dumpExtra() override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -503,7 +503,7 @@ public:
   void dumpExtra() override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 
@@ -554,7 +554,7 @@ public:
   void dumpExtra() override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -626,7 +626,7 @@ public:
   void dumpExtra() override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -647,7 +647,7 @@ public:
   void dumpExtra() override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -673,7 +673,7 @@ public:
 
   bool getIsPrintedAsObject() const override { return false; }
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
 };
 
 } // namespace LibScopeView

--- a/DIVA/LibScopeView/src/Sort.cpp
+++ b/DIVA/LibScopeView/src/Sort.cpp
@@ -94,8 +94,8 @@ bool LibScopeView::sortByOffset(const Object *LHS, const Object *RHS) {
   return compareOffset(LHS, RHS) < 0;
 }
 
-SortFunction LibScopeView::getSortFunction() {
-  switch (getReader()->getPrintSettings().SortKey) {
+SortFunction LibScopeView::getSortFunction(const SortingKey &SortKey) {
+  switch (SortKey) {
   case SortingKey::LINE:
     return sortByLine;
   case SortingKey::OFFSET:

--- a/DIVA/LibScopeView/src/Sort.h
+++ b/DIVA/LibScopeView/src/Sort.h
@@ -34,10 +34,12 @@ namespace LibScopeView {
 
 class Object;
 
+enum class SortingKey { LINE, OFFSET, NAME };
+
 typedef bool (*SortFunction)(const Object *LHS, const Object *RHS);
 
 // Callback functions to sort objects.
-SortFunction getSortFunction();
+SortFunction getSortFunction(const SortingKey &SortKey);
 int compareKind(const Object *LHS, const Object *RHS);
 int compareLine(const Object *LHS, const Object *RHS);
 int compareName(const Object *LHS, const Object *RHS);

--- a/DIVA/LibScopeView/src/Symbol.cpp
+++ b/DIVA/LibScopeView/src/Symbol.cpp
@@ -129,7 +129,8 @@ void Symbol::dump() {
 }
 
 void Symbol::dumpExtra() {
-  GlobalPrintContext->print("%s\n", getAsText().c_str());
+  GlobalPrintContext->print("%s\n",
+                            getAsText(getReader()->getPrintSettings()).c_str());
 }
 
 bool Symbol::dump(bool DoHeader, const char *Header) {
@@ -144,7 +145,7 @@ bool Symbol::dump(bool DoHeader, const char *Header) {
   return DoHeader;
 }
 
-std::string Symbol::getAsText() const {
+std::string Symbol::getAsText(const PrintSettings &Settings) const {
   std::stringstream Result;
   const Symbol *Sym = getIsInlined() ? Reference : this;
   Result << "{" << Sym->getKindAsString() << "}";
@@ -189,8 +190,9 @@ std::string Symbol::getAsText() const {
       Result << " <- ";
     else
       Result << " -> ";
-    Result << Sym->getTypeDieOffsetAsString() << "\""
-           << Sym->getTypeQualifiedName() << Sym->getTypeAsString() << "\"";
+    Result << Sym->getTypeDieOffsetAsString(Settings) << "\""
+           << Sym->getTypeQualifiedName() << Sym->getTypeAsString(Settings)
+           << "\"";
   }
 
   return Result.str();

--- a/DIVA/LibScopeView/src/Symbol.cpp
+++ b/DIVA/LibScopeView/src/Symbol.cpp
@@ -115,32 +115,32 @@ const char *Symbol::resolveName() {
   return getName();
 }
 
-void Symbol::dump() {
-  if (getReader()->getPrintSettings().printObject(*this)) {
+void Symbol::dump(const PrintSettings &Settings) {
+  if (Settings.printObject(*this)) {
     // Object Summary Table.
     getReader()->incrementPrinted(this);
 
     // Common Object Data.
-    Element::dump();
+    Element::dump(Settings);
 
     // Specific Object Data.
-    dumpExtra();
+    dumpExtra(Settings);
   }
 }
 
-void Symbol::dumpExtra() {
-  GlobalPrintContext->print("%s\n",
-                            getAsText(getReader()->getPrintSettings()).c_str());
+void Symbol::dumpExtra(const PrintSettings &Settings) {
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
-bool Symbol::dump(bool DoHeader, const char *Header) {
+bool Symbol::dump(bool DoHeader, const char *Header,
+                  const PrintSettings &Settings) {
   if (DoHeader) {
     GlobalPrintContext->print("\n%s\n", Header);
     DoHeader = false;
   }
 
   // Dump object.
-  dump();
+  dump(Settings);
 
   return DoHeader;
 }

--- a/DIVA/LibScopeView/src/Symbol.h
+++ b/DIVA/LibScopeView/src/Symbol.h
@@ -113,9 +113,10 @@ public:
   }
 
 public:
-  void dump() override;
-  virtual void dumpExtra();
-  virtual bool dump(bool DoHeader, const char *Header);
+  void dump(const PrintSettings &Settings) override;
+  virtual void dumpExtra(const PrintSettings &Settings);
+  virtual bool dump(bool DoHeader, const char *Header,
+                    const PrintSettings &Settings);
 
   /// \brief Returns a text representation of this DIVA Object.
   std::string getAsText(const PrintSettings &Settings) const override;

--- a/DIVA/LibScopeView/src/Symbol.h
+++ b/DIVA/LibScopeView/src/Symbol.h
@@ -118,7 +118,7 @@ public:
   virtual bool dump(bool DoHeader, const char *Header);
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 

--- a/DIVA/LibScopeView/src/Type.cpp
+++ b/DIVA/LibScopeView/src/Type.cpp
@@ -132,7 +132,7 @@ const char *Type::getKindAsString() const {
 
 const char *Type::resolveName() { return getName(); }
 
-bool Type::setFullName() {
+bool Type::setFullName(const PrintSettings &Settings) {
   if (getIsTemplateParam())
     return true;
 
@@ -151,35 +151,35 @@ bool Type::setFullName() {
     BaseScope = static_cast<Scope *>(getType());
   }
 
-  return setFullName(BaseType, BaseScope, nullptr, BaseText);
+  return setFullName(Settings, BaseType, BaseScope, nullptr, BaseText);
 }
 
-void Type::dump() {
-  if (getReader()->getPrintSettings().printObject(*this)) {
+void Type::dump(const PrintSettings &Settings) {
+  if (Settings.printObject(*this)) {
     // Object Summary Table.
     getReader()->incrementPrinted(this);
 
     // Common Object Data.
-    Element::dump();
+    Element::dump(Settings);
 
     // Specific Object Data.
-    dumpExtra();
+    dumpExtra(Settings);
   }
 }
 
-void Type::dumpExtra() {
-  GlobalPrintContext->print("%s\n",
-                            getAsText(getReader()->getPrintSettings()).c_str());
+void Type::dumpExtra(const PrintSettings &Settings) {
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
-bool Type::dump(bool DoHeader, const char *Header) {
+bool Type::dump(bool DoHeader, const char *Header,
+                const PrintSettings &Settings) {
   if (DoHeader) {
     GlobalPrintContext->print("\n%s\n", Header);
     DoHeader = false;
   }
 
   // Dump object.
-  dump();
+  dump(Settings);
 
   return DoHeader;
 }
@@ -254,10 +254,9 @@ Object *TypeDefinition::getUnderlyingType() {
 
 void TypeDefinition::setUnderlyingType(Object *Obj) { setType(Obj); }
 
-void TypeDefinition::dumpExtra() {
+void TypeDefinition::dumpExtra(const PrintSettings &Settings) {
   // Print the full type name.
-  GlobalPrintContext->print("%s\n",
-                            getAsText(getReader()->getPrintSettings()).c_str());
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
 std::string TypeDefinition::getAsText(const PrintSettings &Settings) const {
@@ -296,10 +295,9 @@ void TypeEnumerator::setValue(const char *value) {
 
 size_t TypeEnumerator::getValueIndex() const { return ValueIndex; }
 
-void TypeEnumerator::dumpExtra() {
+void TypeEnumerator::dumpExtra(const PrintSettings &Settings) {
   // Print the full type.
-  GlobalPrintContext->print("%s\n",
-                            getAsText(getReader()->getPrintSettings()).c_str());
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
 std::string TypeEnumerator::getAsText(const PrintSettings &Settings) const {
@@ -341,9 +339,8 @@ void TypeImport::setInheritanceAccess(AccessSpecifier access) {
   InheritanceAccess = access;
 }
 
-void TypeImport::dumpExtra() {
-  GlobalPrintContext->print("%s\n",
-                            getAsText(getReader()->getPrintSettings()).c_str());
+void TypeImport::dumpExtra(const PrintSettings &Settings) {
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
 bool TypeImport::getIsPrintedAsObject() const { return !getIsInheritance(); }
@@ -529,11 +526,10 @@ void TypeParam::setValue(const char *value) {
 
 size_t TypeParam::getValueIndex() const { return ValueIndex; }
 
-void TypeParam::dumpExtra() {
+void TypeParam::dumpExtra(const PrintSettings &Settings) {
   // Depending on the type of parameter, the dump includes different
   // information: type, value or reference to a template.
-  GlobalPrintContext->print("%s\n",
-                            getAsText(getReader()->getPrintSettings()).c_str());
+  GlobalPrintContext->print("%s\n", getAsText(Settings).c_str());
 }
 
 bool TypeParam::getIsPrintedAsObject() const {
@@ -597,10 +593,9 @@ TypeSubrange::TypeSubrange() : Type() {}
 
 TypeSubrange::~TypeSubrange() {}
 
-void TypeSubrange::dumpExtra() {
+void TypeSubrange::dumpExtra(const PrintSettings &Settings) {
   // Print the full type name.
-  GlobalPrintContext->print(
-      "{%s} -> %s'%s' '%s'\n", getKindAsString(),
-      getTypeDieOffsetAsString(getReader()->getPrintSettings()), getTypeName(),
-      getName());
+  GlobalPrintContext->print("{%s} -> %s'%s' '%s'\n", getKindAsString(),
+                            getTypeDieOffsetAsString(Settings), getTypeName(),
+                            getName());
 }

--- a/DIVA/LibScopeView/src/Type.cpp
+++ b/DIVA/LibScopeView/src/Type.cpp
@@ -168,7 +168,8 @@ void Type::dump() {
 }
 
 void Type::dumpExtra() {
-  GlobalPrintContext->print("%s\n", getAsText().c_str());
+  GlobalPrintContext->print("%s\n",
+                            getAsText(getReader()->getPrintSettings()).c_str());
 }
 
 bool Type::dump(bool DoHeader, const char *Header) {
@@ -185,7 +186,7 @@ bool Type::dump(bool DoHeader, const char *Header) {
 
 bool Type::getIsPrintedAsObject() const { return getIsBaseType(); }
 
-std::string Type::getAsText() const {
+std::string Type::getAsText(const PrintSettings &Settings) const {
   std::string Result;
   Result += "{";
   Result += getKindAsString();
@@ -195,7 +196,7 @@ std::string Type::getAsText() const {
   unsigned byte_size = getByteSize();
   if (byte_size) {
     Result += '\n';
-    Result += getAttributeInfoAsText(std::to_string(byte_size));
+    Result += getAttributeInfoAsText(std::to_string(byte_size), Settings);
     Result += " bytes";
   }
   return Result;
@@ -255,17 +256,18 @@ void TypeDefinition::setUnderlyingType(Object *Obj) { setType(Obj); }
 
 void TypeDefinition::dumpExtra() {
   // Print the full type name.
-  GlobalPrintContext->print("%s\n", getAsText().c_str());
+  GlobalPrintContext->print("%s\n",
+                            getAsText(getReader()->getPrintSettings()).c_str());
 }
 
-std::string TypeDefinition::getAsText() const {
+std::string TypeDefinition::getAsText(const PrintSettings &Settings) const {
   std::string Result;
   Result += "{";
   Result += getKindAsString();
   Result += "} \"";
   Result += getName();
   Result += "\" -> ";
-  Result += getTypeDieOffsetAsString();
+  Result += getTypeDieOffsetAsString(Settings);
   Result += "\"";
   if (getType() != nullptr)
     Result += getType()->getName();
@@ -296,14 +298,15 @@ size_t TypeEnumerator::getValueIndex() const { return ValueIndex; }
 
 void TypeEnumerator::dumpExtra() {
   // Print the full type.
-  GlobalPrintContext->print("%s\n", getAsText().c_str());
+  GlobalPrintContext->print("%s\n",
+                            getAsText(getReader()->getPrintSettings()).c_str());
 }
 
-std::string TypeEnumerator::getAsText() const {
+std::string TypeEnumerator::getAsText(const PrintSettings &Settings) const {
   std::string ObjectAsText = "  -";
   std::string Name = getName();
   std::string Value = getValue();
-  std::string DieOffset = getTypeDieOffsetAsString();
+  std::string DieOffset = getTypeDieOffsetAsString(Settings);
 
   ObjectAsText.append(" \"").append(Name).append("\" = ").append(Value);
 
@@ -339,21 +342,17 @@ void TypeImport::setInheritanceAccess(AccessSpecifier access) {
 }
 
 void TypeImport::dumpExtra() {
-  if (getIsInheritance()) {
-    GlobalPrintContext->print("%s\n", getAsText().c_str());
-    return;
-  }
-  // Do not print the full type name; just the imported object.
-  GlobalPrintContext->print("%s\n", getAsText().c_str());
+  GlobalPrintContext->print("%s\n",
+                            getAsText(getReader()->getPrintSettings()).c_str());
 }
 
 bool TypeImport::getIsPrintedAsObject() const { return !getIsInheritance(); }
 
-std::string TypeImport::getAsText() const {
+std::string TypeImport::getAsText(const PrintSettings &Settings) const {
   if (getIsInheritance())
     return getInheritanceAsText();
   else
-    return getUsingAsText();
+    return getUsingAsText(Settings);
 }
 
 std::string TypeImport::getInheritanceAsText() const {
@@ -381,10 +380,10 @@ std::string TypeImport::getInheritanceAsText() const {
   return Result.str();
 }
 
-std::string TypeImport::getUsingAsText() const {
+std::string TypeImport::getUsingAsText(const PrintSettings &Settings) const {
   std::stringstream Result;
   Result << "{" << getKindAsString() << "}";
-  Result << getTypeDieOffsetAsString();
+  Result << getTypeDieOffsetAsString(Settings);
   Object *objtype = getType();
   if (objtype) {
     Scope *Parent = nullptr;
@@ -533,7 +532,8 @@ size_t TypeParam::getValueIndex() const { return ValueIndex; }
 void TypeParam::dumpExtra() {
   // Depending on the type of parameter, the dump includes different
   // information: type, value or reference to a template.
-  GlobalPrintContext->print("%s\n", getAsText().c_str());
+  GlobalPrintContext->print("%s\n",
+                            getAsText(getReader()->getPrintSettings()).c_str());
 }
 
 bool TypeParam::getIsPrintedAsObject() const {
@@ -541,7 +541,7 @@ bool TypeParam::getIsPrintedAsObject() const {
   return !(getParent() && getParent()->getIsTemplatePack());
 }
 
-std::string TypeParam::getAsText() const {
+std::string TypeParam::getAsText(const PrintSettings &Settings) const {
   std::string Result;
   // Template packs print differently.
   const Scope *Parent = getParent();
@@ -555,7 +555,7 @@ std::string TypeParam::getAsText() const {
     Result += "\" ";
   }
   Result += "<- ";
-  Result += getTypeDieOffsetAsString();
+  Result += getTypeDieOffsetAsString(Settings);
 
   if (getIsTemplateType()) {
     Result += "\"";
@@ -599,7 +599,8 @@ TypeSubrange::~TypeSubrange() {}
 
 void TypeSubrange::dumpExtra() {
   // Print the full type name.
-  GlobalPrintContext->print("{%s} -> %s'%s' '%s'\n", getKindAsString(),
-                            getTypeDieOffsetAsString(), getTypeName(),
-                            getName());
+  GlobalPrintContext->print(
+      "{%s} -> %s'%s' '%s'\n", getKindAsString(),
+      getTypeDieOffsetAsString(getReader()->getPrintSettings()), getTypeName(),
+      getName());
 }

--- a/DIVA/LibScopeView/src/Type.h
+++ b/DIVA/LibScopeView/src/Type.h
@@ -193,7 +193,7 @@ public:
 
   // Wrap SetFullName (Used by ElfReader) in a simpler call.
   using Object::setFullName;
-  bool setFullName();
+  bool setFullName(const PrintSettings &Settings);
 
 public:
   // Functions to be implemented by derived classes.
@@ -207,9 +207,10 @@ public:
   virtual size_t getValueIndex() const { return 0; }
 
 public:
-  void dump() override;
-  virtual void dumpExtra();
-  virtual bool dump(bool DoHeader, const char *Header);
+  void dump(const PrintSettings &Settings) override;
+  virtual void dumpExtra(const PrintSettings &Settings);
+  virtual bool dump(bool DoHeader, const char *Header,
+                    const PrintSettings &Settings);
 
   bool getIsPrintedAsObject() const override;
   /// \brief Returns a text representation of this DIVA Object.
@@ -252,7 +253,7 @@ public:
   void setUnderlyingType(Object *Obj) override;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   bool getIsPrintedAsObject() const override { return true; }
   /// \brief Returns a text representation of this DIVA Object.
@@ -281,7 +282,7 @@ public:
   size_t getValueIndex() const override;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   bool getIsPrintedAsObject() const override { return false; }
   /// \brief Returns a text representation of this DIVA Object.
@@ -310,7 +311,7 @@ private:
   AccessSpecifier InheritanceAccess;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   bool getIsPrintedAsObject() const override;
 
@@ -349,7 +350,7 @@ public:
   size_t getValueIndex() const override;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 
   bool getIsPrintedAsObject() const override;
 
@@ -370,7 +371,7 @@ public:
   TypeSubrange(const TypeSubrange &) = delete;
 
 public:
-  void dumpExtra() override;
+  void dumpExtra(const PrintSettings &Settings) override;
 };
 
 } // namespace LibScopeView

--- a/DIVA/LibScopeView/src/Type.h
+++ b/DIVA/LibScopeView/src/Type.h
@@ -213,7 +213,7 @@ public:
 
   bool getIsPrintedAsObject() const override;
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 
@@ -256,7 +256,7 @@ public:
 
   bool getIsPrintedAsObject() const override { return true; }
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -285,7 +285,7 @@ public:
 
   bool getIsPrintedAsObject() const override { return false; }
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };
@@ -315,13 +315,13 @@ public:
   bool getIsPrintedAsObject() const override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 
 private:
   virtual std::string getInheritanceAsText() const;
-  virtual std::string getUsingAsText() const;
+  virtual std::string getUsingAsText(const PrintSettings &Settings) const;
   // Gets a YAML representation of DIVA Object as an Inheritance attribute.
   virtual std::string getInheritanceAsYAML() const;
   virtual std::string getUsingAsYAML() const;
@@ -354,7 +354,7 @@ public:
   bool getIsPrintedAsObject() const override;
 
   /// \brief Returns a text representation of this DIVA Object.
-  std::string getAsText() const override;
+  std::string getAsText(const PrintSettings &Settings) const override;
   /// \brief Returns a YAML representation of this DIVA Object.
   std::string getAsYAML() const override;
 };

--- a/DIVA/UnitTests/src/TestElfDwarfReader/TestElfDwarfReader.cpp
+++ b/DIVA/UnitTests/src/TestElfDwarfReader/TestElfDwarfReader.cpp
@@ -559,13 +559,12 @@ TEST_F(TestElfDwarfReader, ReadImport) {
   // The using statement is on line 7, but the DWARF says line 6.
   EXPECT_EQ(Struct->getTypes().at(0)->getLineNumber(), 6U);
   EXPECT_EQ(getSourceFileName(Struct->getTypes().at(0)), "import.cpp");
-  EXPECT_EQ(Struct->getTypes().at(0)->getDieTag(),
-            DW_TAG_imported_declaration);
+  EXPECT_EQ(Struct->getTypes().at(0)->getDieTag(), DW_TAG_imported_declaration);
   // Check the imported member.
   ASSERT_NE(Struct->getTypes().at(0)->getType(), nullptr);
   ASSERT_TRUE(Struct->getTypes().at(0)->getType()->getIsSymbol());
-  auto *ImpMember = dynamic_cast<LibScopeView::Symbol *>(
-      Struct->getTypes().at(0)->getType());
+  auto *ImpMember =
+      dynamic_cast<LibScopeView::Symbol *>(Struct->getTypes().at(0)->getType());
   EXPECT_EQ(ImpMember->getDieOffset(), 0x37U);
   EXPECT_TRUE(ImpMember->getIsMember());
   EXPECT_STREQ(ImpMember->getName(), "m");
@@ -601,10 +600,10 @@ TEST_F(TestElfDwarfReader, ReadInheritance) {
   auto ProtectedClass = CU->getScopeAt(3);
   ASSERT_TRUE(ProtectedClass->getIsClassType());
   ASSERT_STREQ(ProtectedClass->getName(), "Protected");
-  EXPECT_EQ(dynamic_cast<LibScopeView::TypeImport *>(
-                ProtectedClass->getTypes().at(0))
-                ->getInheritanceAccess(),
-            LibScopeView::AccessSpecifier::Protected);
+  EXPECT_EQ(
+      dynamic_cast<LibScopeView::TypeImport *>(ProtectedClass->getTypes().at(0))
+          ->getInheritanceAccess(),
+      LibScopeView::AccessSpecifier::Protected);
 
   auto DefaultClass = CU->getScopeAt(4);
   ASSERT_TRUE(DefaultClass->getIsClassType());

--- a/DIVA/UnitTests/src/TestElfDwarfReader/TestElfDwarfReader.cpp
+++ b/DIVA/UnitTests/src/TestElfDwarfReader/TestElfDwarfReader.cpp
@@ -98,9 +98,9 @@ public:
       return ::testing::AssertionFailure() << "Test file does not exist";
 
     Settings.SortKey = LibScopeView::SortingKey::OFFSET;
-    Reader = std::make_unique<DwarfReader>(Settings);
+    Reader = std::make_unique<DwarfReader>();
 
-    if (!Reader->loadFile(getTestInputFilePath(TestFile)))
+    if (!Reader->loadFile(getTestInputFilePath(TestFile), Settings))
       return ::testing::AssertionFailure() << "Failed to load test file";
 
     *Root = Reader->getScopesRoot();

--- a/DIVA/UnitTests/src/TestLibScopeView/TestLine.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestLine.cpp
@@ -76,8 +76,8 @@ TEST(Line, getAsText_Line_Attributes) {
   std::string AttrIndent(3 + 4 + 8 + ((Ln.getLevel() + 1) * 2), ' ');
 
   Ln.setIsNewStatement();
-  std::string Expected(
-    std::string("{CodeLine}\n") + AttrIndent + std::string("- NewStatement"));
+  std::string Expected(std::string("{CodeLine}\n") + AttrIndent +
+                       std::string("- NewStatement"));
   EXPECT_EQ(Ln.getAsText(Settings), Expected);
 
   Ln.setIsPrologueEnd();
@@ -120,62 +120,50 @@ TEST(Line, getAsYAML_Line_Attributes) {
                        "attributes:");
 
   Ln.setIsNewStatement();
-  EXPECT_EQ(Ln.getAsYAML(), Expected + (
-    "\n  NewStatement: true"
-    "\n  PrologueEnd: false"
-    "\n  EndSequence: false"
-    "\n  BasicBlock: false"
-    "\n  Discriminator: false"
-    "\n  EpilogueBegin: false"
-  ));
+  EXPECT_EQ(Ln.getAsYAML(), Expected + ("\n  NewStatement: true"
+                                        "\n  PrologueEnd: false"
+                                        "\n  EndSequence: false"
+                                        "\n  BasicBlock: false"
+                                        "\n  Discriminator: false"
+                                        "\n  EpilogueBegin: false"));
 
   Ln.setIsPrologueEnd();
-  EXPECT_EQ(Ln.getAsYAML(), Expected + (
-    "\n  NewStatement: true"
-    "\n  PrologueEnd: true"
-    "\n  EndSequence: false"
-    "\n  BasicBlock: false"
-    "\n  Discriminator: false"
-    "\n  EpilogueBegin: false"
-  ));
+  EXPECT_EQ(Ln.getAsYAML(), Expected + ("\n  NewStatement: true"
+                                        "\n  PrologueEnd: true"
+                                        "\n  EndSequence: false"
+                                        "\n  BasicBlock: false"
+                                        "\n  Discriminator: false"
+                                        "\n  EpilogueBegin: false"));
 
   Ln.setIsLineEndSequence();
-  EXPECT_EQ(Ln.getAsYAML(), Expected + (
-    "\n  NewStatement: true"
-    "\n  PrologueEnd: true"
-    "\n  EndSequence: true"
-    "\n  BasicBlock: false"
-    "\n  Discriminator: false"
-    "\n  EpilogueBegin: false"
-  ));
+  EXPECT_EQ(Ln.getAsYAML(), Expected + ("\n  NewStatement: true"
+                                        "\n  PrologueEnd: true"
+                                        "\n  EndSequence: true"
+                                        "\n  BasicBlock: false"
+                                        "\n  Discriminator: false"
+                                        "\n  EpilogueBegin: false"));
 
   Ln.setIsNewBasicBlock();
-  EXPECT_EQ(Ln.getAsYAML(), Expected + (
-    "\n  NewStatement: true"
-    "\n  PrologueEnd: true"
-    "\n  EndSequence: true"
-    "\n  BasicBlock: true"
-    "\n  Discriminator: false"
-    "\n  EpilogueBegin: false"
-  ));
+  EXPECT_EQ(Ln.getAsYAML(), Expected + ("\n  NewStatement: true"
+                                        "\n  PrologueEnd: true"
+                                        "\n  EndSequence: true"
+                                        "\n  BasicBlock: true"
+                                        "\n  Discriminator: false"
+                                        "\n  EpilogueBegin: false"));
 
   Ln.setHasDiscriminator();
-  EXPECT_EQ(Ln.getAsYAML(), Expected + (
-    "\n  NewStatement: true"
-    "\n  PrologueEnd: true"
-    "\n  EndSequence: true"
-    "\n  BasicBlock: true"
-    "\n  Discriminator: true"
-    "\n  EpilogueBegin: false"
-  ));
+  EXPECT_EQ(Ln.getAsYAML(), Expected + ("\n  NewStatement: true"
+                                        "\n  PrologueEnd: true"
+                                        "\n  EndSequence: true"
+                                        "\n  BasicBlock: true"
+                                        "\n  Discriminator: true"
+                                        "\n  EpilogueBegin: false"));
 
   Ln.setIsEpilogueBegin();
-  EXPECT_EQ(Ln.getAsYAML(), Expected + (
-    "\n  NewStatement: true"
-    "\n  PrologueEnd: true"
-    "\n  EndSequence: true"
-    "\n  BasicBlock: true"
-    "\n  Discriminator: true"
-    "\n  EpilogueBegin: true"
-  ));
+  EXPECT_EQ(Ln.getAsYAML(), Expected + ("\n  NewStatement: true"
+                                        "\n  PrologueEnd: true"
+                                        "\n  EndSequence: true"
+                                        "\n  BasicBlock: true"
+                                        "\n  Discriminator: true"
+                                        "\n  EpilogueBegin: true"));
 }

--- a/DIVA/UnitTests/src/TestLibScopeView/TestLine.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestLine.cpp
@@ -35,18 +35,12 @@
 using namespace LibScopeView;
 
 TEST(Line, getAsText_Line) {
-  Reader R;
-  setReader(&R);
-
   Line Ln(0);
   Ln.setIsLineRecord();
-  EXPECT_EQ(Ln.getAsText(), "{CodeLine}");
+  EXPECT_EQ(Ln.getAsText(PrintSettings()), "{CodeLine}");
 }
 
 TEST(Line, getAsYAML_Line) {
-  Reader R;
-  setReader(&R);
-
   Line Ln;
   Ln.setIsLineRecord();
   Ln.setLineNumber(52);
@@ -74,8 +68,6 @@ TEST(Line, getAsYAML_Line) {
 TEST(Line, getAsText_Line_Attributes) {
   PrintSettings Settings;
   Settings.ShowCodelineAttributes = true;
-  Reader R(Settings);
-  setReader(&R);
 
   Line Ln(/*level*/ 3);
   Ln.setIsLineRecord();
@@ -86,33 +78,30 @@ TEST(Line, getAsText_Line_Attributes) {
   Ln.setIsNewStatement();
   std::string Expected(
     std::string("{CodeLine}\n") + AttrIndent + std::string("- NewStatement"));
-  EXPECT_EQ(Ln.getAsText(), Expected);
+  EXPECT_EQ(Ln.getAsText(Settings), Expected);
 
   Ln.setIsPrologueEnd();
   Expected += '\n' + AttrIndent + std::string("- PrologueEnd");
-  EXPECT_EQ(Ln.getAsText(), Expected);
+  EXPECT_EQ(Ln.getAsText(Settings), Expected);
 
   Ln.setIsLineEndSequence();
   Expected += '\n' + AttrIndent + std::string("- EndSequence");
-  EXPECT_EQ(Ln.getAsText(), Expected);
+  EXPECT_EQ(Ln.getAsText(Settings), Expected);
 
   Ln.setIsNewBasicBlock();
   Expected += '\n' + AttrIndent + std::string("- BasicBlock");
-  EXPECT_EQ(Ln.getAsText(), Expected);
+  EXPECT_EQ(Ln.getAsText(Settings), Expected);
 
   Ln.setHasDiscriminator();
   Expected += '\n' + AttrIndent + std::string("- Discriminator");
-  EXPECT_EQ(Ln.getAsText(), Expected);
+  EXPECT_EQ(Ln.getAsText(Settings), Expected);
 
   Ln.setIsEpilogueBegin();
   Expected += '\n' + AttrIndent + std::string("- EpilogueBegin");
-  EXPECT_EQ(Ln.getAsText(), Expected);
+  EXPECT_EQ(Ln.getAsText(Settings), Expected);
 }
 
 TEST(Line, getAsYAML_Line_Attributes) {
-  Reader R;
-  setReader(&R);
-
   Line Ln;
   Ln.setIsLineRecord();
   Ln.setLineNumber(52);

--- a/DIVA/UnitTests/src/TestLibScopeView/TestObject.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestObject.cpp
@@ -47,17 +47,11 @@ public:
     static std::string Kind("ObjKind");
     return Kind.c_str();
   }
-  const char *getName() const override {
-    return Name.c_str();
-  }
+  const char *getName() const override { return Name.c_str(); }
   size_t getNameIndex() const override { return 0; }
   virtual void setNameIndex(size_t NameIndex) override {}
-  void setName(const char *name) override {
-    Name = name;
-  }
-  const char *getQualifiedName() const override {
-    return QName.c_str();
-  }
+  void setName(const char *name) override { Name = name; }
+  const char *getQualifiedName() const override { return QName.c_str(); }
   void setQualifiedName(const char *name) override {
     setHasQualifiedName();
     QName = name;
@@ -66,19 +60,13 @@ public:
   std::string getFileName(bool format_options) const override {
     return FileName.c_str();
   }
-  void setFileName(const char *fileName) override {
-    FileName = fileName;
-  }
+  void setFileName(const char *fileName) override { FileName = fileName; }
   size_t getFileNameIndex() const override { return 0; }
-  virtual void setFileNameIndex(size_t FilenameIndex) override {};
-  Object *getType() const override {
-    return Type;
-  }
+  virtual void setFileNameIndex(size_t FilenameIndex) override{};
+  Object *getType() const override { return Type; }
   const char *getTypeQualifiedName() const override { return nullptr; }
   bool isNamed() const override { return false; }
-  void setType(Object *object) override {
-    Type = object;
-  }
+  void setType(Object *object) override { Type = object; }
 
   std::string getAsText(const PrintSettings &) const override { return ""; };
   std::string getAsYAML() const override { return ""; };
@@ -92,134 +80,124 @@ private:
   Object *Type;
 };
 
-}
+} // namespace
 
 TEST(Object, getCommonYAML) {
   Reader R;
   setReader(&R);
 
   TestObject TO;
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: null\n"
-            "type: null\n"
-            "source:\n"
-            "  line: null\n"
-            "  file: null\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: null\n"
+                                "type: null\n"
+                                "source:\n"
+                                "  line: null\n"
+                                "  file: null\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   TO.setName("VarName");
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"VarName\"\n"
-            "type: null\n"
-            "source:\n"
-            "  line: null\n"
-            "  file: null\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"VarName\"\n"
+                                "type: null\n"
+                                "source:\n"
+                                "  line: null\n"
+                                "  file: null\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   TO.setQualifiedName("Q::");
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: null\n"
-            "source:\n"
-            "  line: null\n"
-            "  file: null\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: null\n"
+                                "source:\n"
+                                "  line: null\n"
+                                "  file: null\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   Type Ty;
   Ty.setName("Ty");
   TO.setType(&Ty);
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: \"Ty\"\n"
-            "source:\n"
-            "  line: null\n"
-            "  file: null\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: \"Ty\"\n"
+                                "source:\n"
+                                "  line: null\n"
+                                "  file: null\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   Ty.setQualifiedName("Class::");
   Ty.setHasQualifiedName();
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: \"Class::Ty\"\n"
-            "source:\n"
-            "  line: null\n"
-            "  file: null\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: \"Class::Ty\"\n"
+                                "source:\n"
+                                "  line: null\n"
+                                "  file: null\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   TO.setLineNumber(25);
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: \"Class::Ty\"\n"
-            "source:\n"
-            "  line: 25\n"
-            "  file: null\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: \"Class::Ty\"\n"
+                                "source:\n"
+                                "  line: 25\n"
+                                "  file: null\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   TO.setFileName("path/file.cpp");
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: \"Class::Ty\"\n"
-            "source:\n"
-            "  line: 25\n"
-            "  file: \"path/file.cpp\"\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: \"Class::Ty\"\n"
+                                "source:\n"
+                                "  line: 25\n"
+                                "  file: \"path/file.cpp\"\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   TO.setInvalidFileName();
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: \"Class::Ty\"\n"
-            "source:\n"
-            "  line: 25\n"
-            "  file: \"?\"\n"
-            "dwarf:\n"
-            "  offset: 0x0\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: \"Class::Ty\"\n"
+                                "source:\n"
+                                "  line: 25\n"
+                                "  file: \"?\"\n"
+                                "dwarf:\n"
+                                "  offset: 0x0\n"
+                                "  tag: null");
 
   TO.setDieOffset(0x201);
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: \"Class::Ty\"\n"
-            "source:\n"
-            "  line: 25\n"
-            "  file: \"?\"\n"
-            "dwarf:\n"
-            "  offset: 0x201\n"
-            "  tag: null");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: \"Class::Ty\"\n"
+                                "source:\n"
+                                "  line: 25\n"
+                                "  file: \"?\"\n"
+                                "dwarf:\n"
+                                "  offset: 0x201\n"
+                                "  tag: null");
 
   TO.setDieTag(DW_TAG_variable);
-  EXPECT_EQ(TO.getCommonYAML(),
-            "object: \"ObjKind\"\n"
-            "name: \"Q::VarName\"\n"
-            "type: \"Class::Ty\"\n"
-            "source:\n"
-            "  line: 25\n"
-            "  file: \"?\"\n"
-            "dwarf:\n"
-            "  offset: 0x201\n"
-            "  tag: \"DW_TAG_variable\"");
+  EXPECT_EQ(TO.getCommonYAML(), "object: \"ObjKind\"\n"
+                                "name: \"Q::VarName\"\n"
+                                "type: \"Class::Ty\"\n"
+                                "source:\n"
+                                "  line: 25\n"
+                                "  file: \"?\"\n"
+                                "dwarf:\n"
+                                "  offset: 0x201\n"
+                                "  tag: \"DW_TAG_variable\"");
 }
 
 TEST(Object, ResolveQualifiedName) {

--- a/DIVA/UnitTests/src/TestLibScopeView/TestObject.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestObject.cpp
@@ -80,8 +80,8 @@ public:
     Type = object;
   }
 
-  std::string getAsText() const { return nullptr; };
-  std::string getAsYAML() const { return nullptr; };
+  std::string getAsText(const PrintSettings &) const override { return ""; };
+  std::string getAsYAML() const override { return ""; };
 
   using Object::getCommonYAML;
 

--- a/DIVA/UnitTests/src/TestLibScopeView/TestObjectAttributes.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestObjectAttributes.cpp
@@ -39,7 +39,7 @@ using namespace LibScopeView;
 TEST(ObjectAttributes, getAttributesAsText) {
   Reader R;
   setReader(&R);
-  
+
   ScopeRoot Root(-1);
   Root.setIsRoot();
   Root.setDieOffset(0x0cae);

--- a/DIVA/UnitTests/src/TestLibScopeView/TestObjectAttributes.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestObjectAttributes.cpp
@@ -39,7 +39,7 @@ using namespace LibScopeView;
 TEST(ObjectAttributes, getAttributesAsText) {
   Reader R;
   setReader(&R);
-
+  
   ScopeRoot Root(-1);
   Root.setIsRoot();
   Root.setDieOffset(0x0cae);
@@ -78,131 +78,132 @@ TEST(ObjectAttributes, getAttributesAsText) {
 
   // Test the object and parent DIE offsets.
   // Test the type, level and DWARF tag.
-  R.getPrintSettings().ShowDWARFOffset = true;
-  R.getPrintSettings().ShowDWARFParent = true;
-  R.getPrintSettings().ShowLevel = true;
-  R.getPrintSettings().ShowIsGlobal = true;
-  R.getPrintSettings().ShowDWARFTag = true;
+  PrintSettings Settings;
+  Settings.ShowDWARFOffset = true;
+  Settings.ShowDWARFParent = true;
+  Settings.ShowLevel = true;
+  Settings.ShowIsGlobal = true;
+  Settings.ShowDWARFTag = true;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "                           X                                          ");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "[0x0000000b][0x00000cae]000X[DW_TAG_compile_unit]                     ");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "[0x0000000c][0x0000000b]001X[DW_TAG_namespace]                        ");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "[0x000000ba][0x0000000c]002X[DW_TAG_variable]                         ");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "[0x000000ce][0x0000000c]002X[DW_TAG_typedef]                          ");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "                           X                                          ");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "[0x0000000b][0x00000cae]000X[DW_TAG_compile_unit]                     ");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "[0x0000000c][0x0000000b]001X[DW_TAG_namespace]                        ");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "[0x000000ba][0x0000000c]002X[DW_TAG_variable]                         ");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "[0x000000ce][0x0000000c]002X[DW_TAG_typedef]                          ");
 
-  R.getPrintSettings().ShowDWARFOffset = false;
-  R.getPrintSettings().ShowDWARFParent = false;
-  R.getPrintSettings().ShowLevel = false;
-  R.getPrintSettings().ShowIsGlobal = false;
-  R.getPrintSettings().ShowDWARFTag = false;
+  Settings.ShowDWARFOffset = false;
+  Settings.ShowDWARFParent = false;
+  Settings.ShowLevel = false;
+  Settings.ShowIsGlobal = false;
+  Settings.ShowDWARFTag = false;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "");
 
   // Test the object and parent DIE offsets.
-  R.getPrintSettings().ShowDWARFOffset = true;
-  R.getPrintSettings().ShowDWARFParent = true;
+  Settings.ShowDWARFOffset = true;
+  Settings.ShowDWARFParent = true;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "                        ");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "[0x0000000b][0x00000cae]");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "[0x0000000c][0x0000000b]");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "[0x000000ba][0x0000000c]");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "[0x000000ce][0x0000000c]");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "                        ");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "[0x0000000b][0x00000cae]");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "[0x0000000c][0x0000000b]");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "[0x000000ba][0x0000000c]");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "[0x000000ce][0x0000000c]");
 
-  R.getPrintSettings().ShowDWARFOffset = false;
-  R.getPrintSettings().ShowDWARFParent = false;
+  Settings.ShowDWARFOffset = false;
+  Settings.ShowDWARFParent = false;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "");
 
   // Test the object DIE offset.
-  R.getPrintSettings().ShowDWARFOffset = true;
+  Settings.ShowDWARFOffset = true;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "            ");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "[0x0000000b]");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "[0x0000000c]");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "[0x000000ba]");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "[0x000000ce]");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "            ");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "[0x0000000b]");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "[0x0000000c]");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "[0x000000ba]");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "[0x000000ce]");
 
-  R.getPrintSettings().ShowDWARFOffset = false;
+  Settings.ShowDWARFOffset = false;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "");
 
   // Test the object parent DIE offset.
-  R.getPrintSettings().ShowDWARFParent = true;
+  Settings.ShowDWARFParent = true;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "            ");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "[0x00000cae]");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "[0x0000000b]");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "[0x0000000c]");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "[0x0000000c]");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "            ");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "[0x00000cae]");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "[0x0000000b]");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "[0x0000000c]");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "[0x0000000c]");
 
-  R.getPrintSettings().ShowDWARFParent = false;
+  Settings.ShowDWARFParent = false;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "");
 
   // Test the object level.
-  R.getPrintSettings().ShowLevel = true;
+  Settings.ShowLevel = true;
 
-  EXPECT_EQ(Root.getAttributesAsText(), "   ");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "000");
-  EXPECT_EQ(Namespace->getAttributesAsText(), "001");
-  EXPECT_EQ(Variable->getAttributesAsText(), "002");
-  EXPECT_EQ(Typedef->getAttributesAsText(), "002");
+  EXPECT_EQ(Root.getAttributesAsText(Settings), "   ");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "000");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings), "001");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings), "002");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings), "002");
 
-  R.getPrintSettings().ShowLevel = false;
+  Settings.ShowLevel = false;
 
-  EXPECT_EQ(Root.getAttributesAsText(), "");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "");
-  EXPECT_EQ(Namespace->getAttributesAsText(), "");
-  EXPECT_EQ(Variable->getAttributesAsText(), "");
-  EXPECT_EQ(Typedef->getAttributesAsText(), "");
+  EXPECT_EQ(Root.getAttributesAsText(Settings), "");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings), "");
 
   // Test the object DWARF tag.
-  R.getPrintSettings().ShowDWARFTag = true;
+  Settings.ShowDWARFTag = true;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "                                          ");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "[DW_TAG_compile_unit]                     ");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "[DW_TAG_namespace]                        ");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "[DW_TAG_variable]                         ");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "[DW_TAG_typedef]                          ");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "                                          ");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "[DW_TAG_compile_unit]                     ");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "[DW_TAG_namespace]                        ");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "[DW_TAG_variable]                         ");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "[DW_TAG_typedef]                          ");
 
-  R.getPrintSettings().ShowDWARFTag = false;
+  Settings.ShowDWARFTag = false;
 
-  EXPECT_EQ(Root.getAttributesAsText(),         "");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "");
-  EXPECT_EQ(Namespace->getAttributesAsText(),   "");
-  EXPECT_EQ(Variable->getAttributesAsText(),    "");
-  EXPECT_EQ(Typedef->getAttributesAsText(),     "");
+  EXPECT_EQ(Root.getAttributesAsText(Settings),         "");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings),   "");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings),    "");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings),     "");
 
   // Test the object 'global' status.
-  R.getPrintSettings().ShowIsGlobal = true;
+  Settings.ShowIsGlobal = true;
 
-  EXPECT_EQ(Root.getAttributesAsText(), "X");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "X");
-  EXPECT_EQ(Namespace->getAttributesAsText(), "X");
-  EXPECT_EQ(Variable->getAttributesAsText(), "X");
-  EXPECT_EQ(Typedef->getAttributesAsText(), "X");
+  EXPECT_EQ(Root.getAttributesAsText(Settings), "X");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "X");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings), "X");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings), "X");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings), "X");
 
-  R.getPrintSettings().ShowIsGlobal = false;
+  Settings.ShowIsGlobal = false;
 
-  EXPECT_EQ(Root.getAttributesAsText(), "");
-  EXPECT_EQ(CompileUnit->getAttributesAsText(), "");
-  EXPECT_EQ(Namespace->getAttributesAsText(), "");
-  EXPECT_EQ(Variable->getAttributesAsText(), "");
-  EXPECT_EQ(Typedef->getAttributesAsText(), "");
+  EXPECT_EQ(Root.getAttributesAsText(Settings), "");
+  EXPECT_EQ(CompileUnit->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Namespace->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Variable->getAttributesAsText(Settings), "");
+  EXPECT_EQ(Typedef->getAttributesAsText(Settings), "");
 }

--- a/DIVA/UnitTests/src/TestLibScopeView/TestScope.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestScope.cpp
@@ -38,11 +38,11 @@ using namespace LibScopeView;
 
 TEST(Scope, getAsText_Alias) {
   PrintSettings Settings;
-  
+
   ScopeAlias Alias;
   Alias.setIsTemplateAlias();
   EXPECT_EQ(Alias.getAsText(Settings), "{Alias} \"\" -> \"void\"");
-  
+
   Settings.ShowVoid = false;
   EXPECT_EQ(Alias.getAsText(Settings), "{Alias} \"\" -> \"\"");
 
@@ -122,13 +122,13 @@ TEST(Scope, getAsText_Block) {
   TryBlock.setIsBlock();
   TryBlock.setIsTryBlock();
   EXPECT_EQ(TryBlock.getAsText(Settings),
-    std::string("{Block}\n") + AttrIndent + std::string("- try"));
+            std::string("{Block}\n") + AttrIndent + std::string("- try"));
 
   Scope CatchBlock(/*Level*/ 3);
   CatchBlock.setIsBlock();
   CatchBlock.setIsCatchBlock();
   EXPECT_EQ(CatchBlock.getAsText(Settings),
-    std::string("{Block}\n") + AttrIndent + std::string("- catch"));
+            std::string("{Block}\n") + AttrIndent + std::string("- catch"));
 }
 
 TEST(Scope, getAsYAML_Block) {
@@ -194,7 +194,7 @@ TEST(Scope, getAsYAML_Block) {
 
 TEST(Scope, getAsText_Class) {
   PrintSettings Settings;
-  
+
   ScopeAggregate Class;
   Class.setIsAggregate();
   Class.setIsClassType();
@@ -208,13 +208,14 @@ TEST(Scope, getAsText_Class) {
 
   Class.setIsTemplate();
   EXPECT_EQ(Class.getAsText(Settings), std::string("{Class} \"TestClass\"\n") +
-                                   AttrIndent + std::string("Template"));
+                                           AttrIndent +
+                                           std::string("Template"));
 }
 
 TEST(Scope, getAsYAML_Class) {
   Reader R;
   setReader(&R);
-  
+
   ScopeAggregate Class;
   Class.setIsAggregate();
   Class.setIsClassType();
@@ -227,7 +228,7 @@ TEST(Scope, getAsYAML_Class) {
   ScopeAggregate ParentClass;
   ParentClass.setName("TestParentClass");
 
-  TypeImport * TyImport = new TypeImport;
+  TypeImport *TyImport = new TypeImport;
   TyImport->setIsInheritance();
   TyImport->setType(&ParentClass);
   TyImport->setInheritanceAccess(AccessSpecifier::Public);
@@ -262,7 +263,7 @@ TEST(Scope, getAsYAML_Class) {
 TEST(Scope, getAsYAML_multiInheritance) {
   Reader R;
   setReader(&R);
-  
+
   ScopeAggregate Class;
   Class.setIsAggregate();
   Class.setIsClassType();
@@ -275,7 +276,7 @@ TEST(Scope, getAsYAML_multiInheritance) {
   ScopeAggregate ParentClassA;
   ParentClassA.setName("TestParentClassA");
 
-  TypeImport * TyImportA = new TypeImport;
+  TypeImport *TyImportA = new TypeImport;
   TyImportA->setIsInheritance();
   TyImportA->setType(&ParentClassA);
   TyImportA->setInheritanceAccess(AccessSpecifier::Public);
@@ -283,7 +284,7 @@ TEST(Scope, getAsYAML_multiInheritance) {
   ScopeAggregate ParentClassB;
   ParentClassB.setName("TestParentClassB");
 
-  TypeImport * TyImportB = new TypeImport;
+  TypeImport *TyImportB = new TypeImport;
   TyImportB->setIsInheritance();
   TyImportB->setType(&ParentClassB);
   TyImportB->setInheritanceAccess(AccessSpecifier::Protected);
@@ -312,7 +313,7 @@ TEST(Scope, getAsYAML_multiInheritance) {
 TEST(Scope, getAsYAML_Unspecified_Class) {
   Reader R;
   setReader(&R);
-  
+
   ScopeAggregate Class;
   Class.setIsAggregate();
   Class.setIsClassType();
@@ -325,7 +326,7 @@ TEST(Scope, getAsYAML_Unspecified_Class) {
   ScopeAggregate ParentStruct;
   ParentStruct.setName("TestParentStruct");
 
-  TypeImport * TyImport = new TypeImport;
+  TypeImport *TyImport = new TypeImport;
   TyImport->setIsInheritance();
   TyImport->setType(&ParentStruct);
   TyImport->setInheritanceAccess(AccessSpecifier::Unspecified);
@@ -389,8 +390,7 @@ TEST(Scope, getAsText_Enumeration) {
   EXPECT_EQ(ScpEnumeration.getAsText(PrintSettings()), "{Enum} \"days\"");
 
   ScpEnumeration.setIsClass();
-  EXPECT_EQ(ScpEnumeration.getAsText(PrintSettings()),
-            "{Enum} class \"days\"");
+  EXPECT_EQ(ScpEnumeration.getAsText(PrintSettings()), "{Enum} class \"days\"");
 
   Type Ty;
   Ty.setName("unsigned int");
@@ -403,7 +403,7 @@ TEST(Scope, getAsText_Enumeration) {
 TEST(Scope, getAsYAML_Enumeration) {
   Reader R;
   setReader(&R);
-  
+
   ScopeEnumeration Enum;
   Enum.setIsEnumerationType();
   Enum.setName("days");
@@ -415,18 +415,16 @@ TEST(Scope, getAsYAML_Enumeration) {
   Ty.setName("unsigned int");
   Enum.setName("days");
   Enum.setType(&Ty);
-  std::string ExpectedYAML(
-    "object: \"Enum\"\n"
-    "name: \"days\"\n"
-    "type: \"unsigned int\"\n"
-    "source:\n"
-    "  line: 42\n"
-    "  file: \"enum.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xfeed\n"
-    "  tag: \"DW_TAG_enumeration_type\"\n"
-    "attributes:"
-  );
+  std::string ExpectedYAML("object: \"Enum\"\n"
+                           "name: \"days\"\n"
+                           "type: \"unsigned int\"\n"
+                           "source:\n"
+                           "  line: 42\n"
+                           "  file: \"enum.cpp\"\n"
+                           "dwarf:\n"
+                           "  offset: 0xfeed\n"
+                           "  tag: \"DW_TAG_enumeration_type\"\n"
+                           "attributes:");
   EXPECT_EQ(Enum.getAsYAML(),
             ExpectedYAML + "\n  class: false\n  enumerators: []");
 
@@ -463,7 +461,7 @@ TEST(Scope, getAsText_Function) {
   ScopeFunction ScpFunc(0);
   ScpFunc.setIsScope();
   ScpFunc.setIsFunction();
-  
+
   EXPECT_EQ(ScpFunc.getAsText(Settings),
             std::string("{Function} \"\" -> \"void\"\n" + AttrIndent +
                         std::string("No declaration")));
@@ -601,9 +599,9 @@ TEST(Scope, getAsText_Function_Attributes) {
   inlined.setIsInlinedSubroutine();
   inlined.setName("Foo");
   EXPECT_EQ(inlined.getAsText(Settings),
-    std::string("{Function} \"Foo\" -> \"\"\n") +
-      AttrIndent + std::string("No declaration\n") +
-      AttrIndent + std::string("Inlined"));
+            std::string("{Function} \"Foo\" -> \"\"\n") + AttrIndent +
+                std::string("No declaration\n") + AttrIndent +
+                std::string("Inlined"));
 }
 
 TEST(Scope, getAsYAML_Function) {
@@ -618,121 +616,111 @@ TEST(Scope, getAsYAML_Function) {
 
   // Normal function.
   // No type is "void".
-  EXPECT_EQ(Func.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"void\"\n"
-    "source:\n"
-    "  line: 17\n"
-    "  file: \"foo.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xce\n"
-    "  tag: \"DW_TAG_subprogram\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: null\n"
-    "    line: null\n"
-    "  is_template: false\n"
-    "  static: false\n"
-    "  inline: false\n"
-    "  is_inlined: false\n"
-    "  is_declaration: false"
-  );
+  EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
+                              "name: \"Foo\"\n"
+                              "type: \"void\"\n"
+                              "source:\n"
+                              "  line: 17\n"
+                              "  file: \"foo.cpp\"\n"
+                              "dwarf:\n"
+                              "  offset: 0xce\n"
+                              "  tag: \"DW_TAG_subprogram\"\n"
+                              "attributes:\n"
+                              "  declaration:\n"
+                              "    file: null\n"
+                              "    line: null\n"
+                              "  is_template: false\n"
+                              "  static: false\n"
+                              "  inline: false\n"
+                              "  is_inlined: false\n"
+                              "  is_declaration: false");
 
   Type Ty(0);
   Ty.setName("int");
   Func.setType(&Ty);
-  EXPECT_EQ(Func.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"int\"\n"
-    "source:\n"
-    "  line: 17\n"
-    "  file: \"foo.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xce\n"
-    "  tag: \"DW_TAG_subprogram\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: null\n"
-    "    line: null\n"
-    "  is_template: false\n"
-    "  static: false\n"
-    "  inline: false\n"
-    "  is_inlined: false\n"
-    "  is_declaration: false"
-  );
+  EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
+                              "name: \"Foo\"\n"
+                              "type: \"int\"\n"
+                              "source:\n"
+                              "  line: 17\n"
+                              "  file: \"foo.cpp\"\n"
+                              "dwarf:\n"
+                              "  offset: 0xce\n"
+                              "  tag: \"DW_TAG_subprogram\"\n"
+                              "attributes:\n"
+                              "  declaration:\n"
+                              "    file: null\n"
+                              "    line: null\n"
+                              "  is_template: false\n"
+                              "  static: false\n"
+                              "  inline: false\n"
+                              "  is_inlined: false\n"
+                              "  is_declaration: false");
 
   // Declaration for inlined function.
   Func.setIsInlined();
   Func.setIsDeclaredInline();
-  EXPECT_EQ(Func.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"int\"\n"
-    "source:\n"
-    "  line: 17\n"
-    "  file: \"foo.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xce\n"
-    "  tag: \"DW_TAG_subprogram\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: null\n"
-    "    line: null\n"
-    "  is_template: false\n"
-    "  static: false\n"
-    "  inline: true\n"
-    "  is_inlined: true\n"
-    "  is_declaration: false"
-  );
+  EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
+                              "name: \"Foo\"\n"
+                              "type: \"int\"\n"
+                              "source:\n"
+                              "  line: 17\n"
+                              "  file: \"foo.cpp\"\n"
+                              "dwarf:\n"
+                              "  offset: 0xce\n"
+                              "  tag: \"DW_TAG_subprogram\"\n"
+                              "attributes:\n"
+                              "  declaration:\n"
+                              "    file: null\n"
+                              "    line: null\n"
+                              "  is_template: false\n"
+                              "  static: false\n"
+                              "  inline: true\n"
+                              "  is_inlined: true\n"
+                              "  is_declaration: false");
 
   // Declaration for Static function.
   Func.setIsStatic();
   Func.setIsDeclaration();
-  EXPECT_EQ(Func.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"int\"\n"
-    "source:\n"
-    "  line: 17\n"
-    "  file: \"foo.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xce\n"
-    "  tag: \"DW_TAG_subprogram\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: null\n"
-    "    line: null\n"
-    "  is_template: false\n"
-    "  static: true\n"
-    "  inline: true\n"
-    "  is_inlined: true\n"
-    "  is_declaration: true"
-  );
+  EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
+                              "name: \"Foo\"\n"
+                              "type: \"int\"\n"
+                              "source:\n"
+                              "  line: 17\n"
+                              "  file: \"foo.cpp\"\n"
+                              "dwarf:\n"
+                              "  offset: 0xce\n"
+                              "  tag: \"DW_TAG_subprogram\"\n"
+                              "attributes:\n"
+                              "  declaration:\n"
+                              "    file: null\n"
+                              "    line: null\n"
+                              "  is_template: false\n"
+                              "  static: true\n"
+                              "  inline: true\n"
+                              "  is_inlined: true\n"
+                              "  is_declaration: true");
 
   // Template function.
   Func.setIsTemplate();
-  EXPECT_EQ(Func.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"int\"\n"
-    "source:\n"
-    "  line: 17\n"
-    "  file: \"foo.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xce\n"
-    "  tag: \"DW_TAG_subprogram\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: null\n"
-    "    line: null\n"
-    "  is_template: true\n"
-    "  static: true\n"
-    "  inline: true\n"
-    "  is_inlined: true\n"
-    "  is_declaration: true"
-  );
+  EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
+                              "name: \"Foo\"\n"
+                              "type: \"int\"\n"
+                              "source:\n"
+                              "  line: 17\n"
+                              "  file: \"foo.cpp\"\n"
+                              "dwarf:\n"
+                              "  offset: 0xce\n"
+                              "  tag: \"DW_TAG_subprogram\"\n"
+                              "attributes:\n"
+                              "  declaration:\n"
+                              "    file: null\n"
+                              "    line: null\n"
+                              "  is_template: true\n"
+                              "  static: true\n"
+                              "  inline: true\n"
+                              "  is_inlined: true\n"
+                              "  is_declaration: true");
 
   // Function to be used as Reference.
   ScopeFunction Reference(0);
@@ -745,50 +733,46 @@ TEST(Scope, getAsYAML_Function) {
 
   // Reference to function.
   Func.setReference(&Reference);
-  EXPECT_EQ(Func.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"int\"\n"
-    "source:\n"
-    "  line: 17\n"
-    "  file: \"foo.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xce\n"
-    "  tag: \"DW_TAG_subprogram\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: \"ref.cpp\"\n"
-    "    line: 620\n"
-    "  is_template: true\n"
-    "  static: true\n"
-    "  inline: true\n"
-    "  is_inlined: true\n"
-    "  is_declaration: true"
-  );
+  EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
+                              "name: \"Foo\"\n"
+                              "type: \"int\"\n"
+                              "source:\n"
+                              "  line: 17\n"
+                              "  file: \"foo.cpp\"\n"
+                              "dwarf:\n"
+                              "  offset: 0xce\n"
+                              "  tag: \"DW_TAG_subprogram\"\n"
+                              "attributes:\n"
+                              "  declaration:\n"
+                              "    file: \"ref.cpp\"\n"
+                              "    line: 620\n"
+                              "  is_template: true\n"
+                              "  static: true\n"
+                              "  inline: true\n"
+                              "  is_inlined: true\n"
+                              "  is_declaration: true");
 
   // Invalid Reference to function.
   Reference.setInvalidFileName();
   Reference.setLineNumber(0);
-  EXPECT_EQ(Func.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"int\"\n"
-    "source:\n"
-    "  line: 17\n"
-    "  file: \"foo.cpp\"\n"
-    "dwarf:\n"
-    "  offset: 0xce\n"
-    "  tag: \"DW_TAG_subprogram\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: \"?\"\n"
-    "    line: 0\n"
-    "  is_template: true\n"
-    "  static: true\n"
-    "  inline: true\n"
-    "  is_inlined: true\n"
-    "  is_declaration: true"
-  );
+  EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
+                              "name: \"Foo\"\n"
+                              "type: \"int\"\n"
+                              "source:\n"
+                              "  line: 17\n"
+                              "  file: \"foo.cpp\"\n"
+                              "dwarf:\n"
+                              "  offset: 0xce\n"
+                              "  tag: \"DW_TAG_subprogram\"\n"
+                              "attributes:\n"
+                              "  declaration:\n"
+                              "    file: \"?\"\n"
+                              "    line: 0\n"
+                              "  is_template: true\n"
+                              "  static: true\n"
+                              "  inline: true\n"
+                              "  is_inlined: true\n"
+                              "  is_declaration: true");
 
   // ScopeFunctionInlined.
   ScopeFunctionInlined Inlined(0);
@@ -797,26 +781,24 @@ TEST(Scope, getAsYAML_Function) {
   Inlined.setDieOffset(0x100);
   Inlined.setDieTag(DW_TAG_inlined_subroutine);
 
-  EXPECT_EQ(Inlined.getAsYAML(),
-    "object: \"Function\"\n"
-    "name: \"Foo\"\n"
-    "type: \"void\"\n"
-    "source:\n"
-    "  line: null\n"
-    "  file: null\n"
-    "dwarf:\n"
-    "  offset: 0x100\n"
-    "  tag: \"DW_TAG_inlined_subroutine\"\n"
-    "attributes:\n"
-    "  declaration:\n"
-    "    file: null\n"
-    "    line: null\n"
-    "  is_template: false\n"
-    "  static: false\n"
-    "  inline: false\n"
-    "  is_inlined: true\n"
-    "  is_declaration: false"
-  );
+  EXPECT_EQ(Inlined.getAsYAML(), "object: \"Function\"\n"
+                                 "name: \"Foo\"\n"
+                                 "type: \"void\"\n"
+                                 "source:\n"
+                                 "  line: null\n"
+                                 "  file: null\n"
+                                 "dwarf:\n"
+                                 "  offset: 0x100\n"
+                                 "  tag: \"DW_TAG_inlined_subroutine\"\n"
+                                 "attributes:\n"
+                                 "  declaration:\n"
+                                 "    file: null\n"
+                                 "    line: null\n"
+                                 "  is_template: false\n"
+                                 "  static: false\n"
+                                 "  inline: false\n"
+                                 "  is_inlined: true\n"
+                                 "  is_declaration: false");
 }
 
 TEST(Scope, getAsText_Namespace) {
@@ -886,7 +868,7 @@ TEST(Scope, getAsText_Struct) {
 TEST(Scope, getAsYAML_Struct) {
   Reader R;
   setReader(&R);
-  
+
   ScopeAggregate Struct;
   Struct.setIsAggregate();
   Struct.setIsStructType();
@@ -899,7 +881,7 @@ TEST(Scope, getAsYAML_Struct) {
   ScopeAggregate ParentClass;
   ParentClass.setName("TestParentClass");
 
-  TypeImport * TyImport = new TypeImport;
+  TypeImport *TyImport = new TypeImport;
   TyImport->setIsInheritance();
   TyImport->setType(&ParentClass);
   TyImport->setInheritanceAccess(AccessSpecifier::Private);
@@ -934,7 +916,7 @@ TEST(Scope, getAsYAML_Struct) {
 TEST(Scope, getAsYAML_Unspecified_Struct) {
   Reader R;
   setReader(&R);
-  
+
   ScopeAggregate Struct;
   Struct.setIsAggregate();
   Struct.setIsStructType();
@@ -948,11 +930,10 @@ TEST(Scope, getAsYAML_Unspecified_Struct) {
   ParentClass.setName("TestParentClass");
   ParentClass.setIsStructType();
 
-  TypeImport * TyImport = new TypeImport;
+  TypeImport *TyImport = new TypeImport;
   TyImport->setIsInheritance();
   TyImport->setType(&ParentClass);
   TyImport->setInheritanceAccess(AccessSpecifier::Unspecified);
-
 
   Struct.addObject(TyImport);
 
@@ -985,7 +966,7 @@ TEST(Scope, getAsText_TemplatePack) {
 TEST(Scope, getAsYAML_TemplatePack) {
   Reader R;
   setReader(&R);
-  
+
   ScopeTemplatePack Pack;
   Pack.setIsTemplatePack();
   Pack.setName("TPack");
@@ -1036,7 +1017,7 @@ TEST(Scope, getAsYAML_TemplatePack) {
 
 TEST(Scope, getAsText_Union) {
   PrintSettings Settings;
-  
+
   ScopeAggregate Union;
   Union.setIsAggregate();
   Union.setIsUnionType();
@@ -1050,7 +1031,8 @@ TEST(Scope, getAsText_Union) {
 
   Union.setIsTemplate();
   EXPECT_EQ(Union.getAsText(Settings), std::string("{Union} \"TestUnion\"\n") +
-                AttrIndent + std::string("Template"));
+                                           AttrIndent +
+                                           std::string("Template"));
 }
 
 TEST(Scope, getAsYAML_Union) {

--- a/DIVA/UnitTests/src/TestLibScopeView/TestSymbol.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestSymbol.cpp
@@ -37,51 +37,49 @@
 using namespace LibScopeView;
 
 TEST(Symbol, getAsText_Member) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   Symbol Sym;
   Sym.setIsMember();
   Sym.setAccessSpecifier(AccessSpecifier::Private);
-  EXPECT_EQ(Sym.getAsText(), "{Member} private -> \"void\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Member} private -> \"void\"");
 
-  R.getPrintSettings().ShowVoid = false;
-  EXPECT_EQ(Sym.getAsText(), "{Member} private -> \"\"");
+  Settings.ShowVoid = false;
+  EXPECT_EQ(Sym.getAsText(Settings), "{Member} private -> \"\"");
 
   Sym.setName("Var");
-  EXPECT_EQ(Sym.getAsText(), "{Member} private \"Var\" -> \"\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Member} private \"Var\" -> \"\"");
 
   Type Ty;
   Ty.setIsBaseType();
   Ty.setName("VarType");
   Sym.setType(&Ty);
-  EXPECT_EQ(Sym.getAsText(), "{Member} private \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Member} private \"Var\" -> \"VarType\"");
 
   Sym.setAccessSpecifier(AccessSpecifier::Protected);
-  EXPECT_EQ(Sym.getAsText(), "{Member} protected \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings),
+            "{Member} protected \"Var\" -> \"VarType\"");
 
   Sym.setAccessSpecifier(AccessSpecifier::Public);
-  EXPECT_EQ(Sym.getAsText(), "{Member} public \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Member} public \"Var\" -> \"VarType\"");
 
   ScopeAggregate ParentClass;
   ParentClass.setIsClassType();
   Sym.setParent(&ParentClass);
   Sym.setAccessSpecifier(AccessSpecifier::Unspecified);
-  EXPECT_EQ(Sym.getAsText(), "{Member} private \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Member} private \"Var\" -> \"VarType\"");
 
   ScopeAggregate ParentStruct;
   ParentStruct.setIsStructType();
   Sym.setParent(&ParentStruct);
-  EXPECT_EQ(Sym.getAsText(), "{Member} public \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Member} public \"Var\" -> \"VarType\"");
 
   Sym.setIsStatic();
-  EXPECT_EQ(Sym.getAsText(), "{Member} public static \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings),
+            "{Member} public static \"Var\" -> \"VarType\"");
 }
 
 TEST(Symbol, getAsYAML_Member) {
-  Reader R;
-  setReader(&R);
-
   Symbol Sym;
   Sym.setIsMember();
   Sym.setName("Var");
@@ -142,41 +140,37 @@ TEST(Symbol, getAsYAML_Member) {
 }
 
 TEST(Symbol, getAsText_Parameter) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   Symbol Sym(0);
   Sym.setIsParameter();
-  EXPECT_EQ(Sym.getAsText(), "{Parameter} -> \"void\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} -> \"void\"");
 
-  R.getPrintSettings().ShowVoid = false;
-  EXPECT_EQ(Sym.getAsText(), "{Parameter} -> \"\"");
+  Settings.ShowVoid = false;
+  EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} -> \"\"");
 
   Sym.setName("qaz");
-  EXPECT_EQ(Sym.getAsText(), "{Parameter} \"qaz\" -> \"\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} \"qaz\" -> \"\"");
 
   Type Ty(0);
   Ty.setIsBaseType();
   Ty.setName("wsx");
   Sym.setType(&Ty);
-  EXPECT_EQ(Sym.getAsText(), "{Parameter} \"qaz\" -> \"wsx\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} \"qaz\" -> \"wsx\"");
 
   // Templates have the indicator reversed '<-'.
   Scope Scp(0);
   Scp.setIsScope();
   Scp.setIsTemplate();
   Sym.setParent(&Scp);
-  EXPECT_EQ(Sym.getAsText(), "{Parameter} \"qaz\" <- \"wsx\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} \"qaz\" <- \"wsx\"");
 
   Symbol Unspec;
   Unspec.setIsUnspecifiedParameter();
-  EXPECT_EQ(Unspec.getAsText(), "{Parameter} \"...\"");
+  EXPECT_EQ(Unspec.getAsText(Settings), "{Parameter} \"...\"");
 }
 
 TEST(Symbol, getAsYAML_Parameter) {
-  Reader R;
-  setReader(&R);
-
   Symbol Sym;
   Sym.setIsParameter();
   Sym.setName("qaz");
@@ -219,38 +213,35 @@ TEST(Symbol, getAsYAML_Parameter) {
 }
 
 TEST(Symbol, getAsText_Variable) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   Symbol Sym;
   Sym.setIsVariable();
-  EXPECT_EQ(Sym.getAsText(), "{Variable} -> \"void\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Variable} -> \"void\"");
 
-  R.getPrintSettings().ShowVoid = false;
-  EXPECT_EQ(Sym.getAsText(), "{Variable} -> \"\"");
+  Settings.ShowVoid = false;
+  EXPECT_EQ(Sym.getAsText(Settings), "{Variable} -> \"\"");
 
   Sym.setName("Var");
-  EXPECT_EQ(Sym.getAsText(), "{Variable} \"Var\" -> \"\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Variable} \"Var\" -> \"\"");
 
   Type Ty;
   Ty.setIsBaseType();
   Ty.setName("VarType");
   Sym.setType(&Ty);
-  EXPECT_EQ(Sym.getAsText(), "{Variable} \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings), "{Variable} \"Var\" -> \"VarType\"");
 
   Sym.setIsStatic();
-  EXPECT_EQ(Sym.getAsText(), "{Variable} static \"Var\" -> \"VarType\"");
+  EXPECT_EQ(Sym.getAsText(Settings),
+            "{Variable} static \"Var\" -> \"VarType\"");
 
   Sym.setQualifiedName("Base::Class::");
   Sym.setHasQualifiedName();
-  EXPECT_EQ(Sym.getAsText(),
+  EXPECT_EQ(Sym.getAsText(Settings),
             "{Variable} static \"Base::Class::Var\" -> \"VarType\"");
 }
 
 TEST(Symbol, getAsYAML_Variable) {
-  Reader R;
-  setReader(&R);
-
   Symbol Sym;
   Sym.setIsVariable();
   Sym.setName("Var");

--- a/DIVA/UnitTests/src/TestLibScopeView/TestSymbol.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestSymbol.cpp
@@ -108,15 +108,15 @@ TEST(Symbol, getAsYAML_Member) {
             CommonExpected + std::string("  access_specifier: \"private\""));
 
   EXPECT_EQ(Sym.getAsYAML(),
-    CommonExpected + std::string("  access_specifier: \"private\""));
+            CommonExpected + std::string("  access_specifier: \"private\""));
 
   Sym.setAccessSpecifier(AccessSpecifier::Protected);
   EXPECT_EQ(Sym.getAsYAML(),
-    CommonExpected + std::string("  access_specifier: \"protected\""));
+            CommonExpected + std::string("  access_specifier: \"protected\""));
 
   Sym.setAccessSpecifier(AccessSpecifier::Public);
   EXPECT_EQ(Sym.getAsYAML(),
-    CommonExpected + std::string("  access_specifier: \"public\""));
+            CommonExpected + std::string("  access_specifier: \"public\""));
 
   // Unspecified access in a class is private.
   ScopeAggregate ParentClass;
@@ -124,19 +124,18 @@ TEST(Symbol, getAsYAML_Member) {
   Sym.setParent(&ParentClass);
   Sym.setAccessSpecifier(AccessSpecifier::Unspecified);
   EXPECT_EQ(Sym.getAsYAML(),
-    CommonExpected + std::string("  access_specifier: \"private\""));
+            CommonExpected + std::string("  access_specifier: \"private\""));
 
   // Unspecified access in a scope is public.
   ScopeAggregate ParentStruct;
   ParentStruct.setIsStructType();
   Sym.setParent(&ParentStruct);
   EXPECT_EQ(Sym.getAsYAML(),
-    CommonExpected + std::string("  access_specifier: \"public\""));
+            CommonExpected + std::string("  access_specifier: \"public\""));
 
   Sym.setIsStatic();
   EXPECT_EQ(Sym.getAsYAML(),
-            CommonExpected +
-                std::string("  access_specifier: \"public\""));
+            CommonExpected + std::string("  access_specifier: \"public\""));
 }
 
 TEST(Symbol, getAsText_Parameter) {

--- a/DIVA/UnitTests/src/TestLibScopeView/TestType.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestType.cpp
@@ -47,7 +47,6 @@ TEST(Type, getAsText_Enumerator) {
   TyEnumerator.setValue("10");
   EXPECT_EQ(TyEnumerator.getAsText(Settings), "  - \"mon\" = 10");
 
-
   Settings.ShowDWARFOffset = true;
   TyEnumerator.setDieOffset(0x0);
   EXPECT_EQ(TyEnumerator.getAsText(Settings), "  - \"mon\" = 10 [0x00000000]");
@@ -232,7 +231,7 @@ TEST(Type, getAsYAML_Param) {
 TEST(Type, getAsText_PrimitiveType) {
   PrintSettings Settings;
 
-  Type Ty(/*level*/3);
+  Type Ty(/*level*/ 3);
   Ty.setIsBaseType();
   Ty.setIncludeInPrint();
 
@@ -246,11 +245,13 @@ TEST(Type, getAsText_PrimitiveType) {
 
   Ty.setByteSize(4);
   EXPECT_EQ(Ty.getAsText(Settings), std::string("{PrimitiveType} -> \"qaz\"") +
-    '\n' + AttrIndent + std::string("- 4 bytes"));
+                                        '\n' + AttrIndent +
+                                        std::string("- 4 bytes"));
 
   Ty.setByteSize(23);
   EXPECT_EQ(Ty.getAsText(Settings), std::string("{PrimitiveType} -> \"qaz\"") +
-    '\n' + AttrIndent + std::string("- 23 bytes"));
+                                        '\n' + AttrIndent +
+                                        std::string("- 23 bytes"));
 }
 
 TEST(Type, getAsYAML_PrimitiveType) {
@@ -363,7 +364,7 @@ TEST(Type, getAsText_Using) {
 
   Variable.setParent(&Parent);
   EXPECT_EQ(UsingVariable.getAsText(Settings),
-    "{Using} variable \"parent::test_variable\"");
+            "{Using} variable \"parent::test_variable\"");
 
   TypeImport UsingMember;
   UsingMember.setIsImportedDeclaration();
@@ -373,11 +374,11 @@ TEST(Type, getAsText_Using) {
   Member.setParent(&CU);
   UsingMember.setType(&Member);
   EXPECT_EQ(UsingMember.getAsText(Settings),
-    "{Using} variable \"test_member\"");
+            "{Using} variable \"test_member\"");
 
   Member.setParent(&Parent);
   EXPECT_EQ(UsingMember.getAsText(Settings),
-    "{Using} variable \"parent::test_member\"");
+            "{Using} variable \"parent::test_member\"");
 
   TypeImport UsingFunction;
   UsingFunction.setIsImportedDeclaration();
@@ -391,7 +392,7 @@ TEST(Type, getAsText_Using) {
 
   Func.setParent(&Parent);
   EXPECT_EQ(UsingFunction.getAsText(Settings),
-    "{Using} function \"parent::test_function\"");
+            "{Using} function \"parent::test_function\"");
 
   TypeImport UsingStruct;
   UsingStruct.setIsImportedDeclaration();
@@ -411,7 +412,7 @@ TEST(Type, getAsText_Using) {
   GrandParent.setName("grandparent");
   Parent.setParent(&GrandParent);
   EXPECT_EQ(UsingFunction.getAsText(Settings),
-    "{Using} function \"grandparent::parent::test_function\"");
+            "{Using} function \"grandparent::parent::test_function\"");
 }
 
 TEST(Type, getAsYAML_Using) {

--- a/DIVA/UnitTests/src/TestLibScopeView/TestType.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestType.cpp
@@ -37,21 +37,20 @@
 using namespace LibScopeView;
 
 TEST(Type, getAsText_Enumerator) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   TypeEnumerator TyEnumerator;
 
   TyEnumerator.setName("mon");
-  EXPECT_EQ(TyEnumerator.getAsText(), "  - \"mon\" = ");
+  EXPECT_EQ(TyEnumerator.getAsText(Settings), "  - \"mon\" = ");
 
   TyEnumerator.setValue("10");
-  EXPECT_EQ(TyEnumerator.getAsText(), "  - \"mon\" = 10");
+  EXPECT_EQ(TyEnumerator.getAsText(Settings), "  - \"mon\" = 10");
 
 
-  R.getPrintSettings().ShowDWARFOffset = true;
+  Settings.ShowDWARFOffset = true;
   TyEnumerator.setDieOffset(0x0);
-  EXPECT_EQ(TyEnumerator.getAsText(), "  - \"mon\" = 10 [0x00000000]");
+  EXPECT_EQ(TyEnumerator.getAsText(Settings), "  - \"mon\" = 10 [0x00000000]");
 }
 
 TEST(Type, getAsYAML_Enumerator) {
@@ -61,8 +60,7 @@ TEST(Type, getAsYAML_Enumerator) {
 }
 
 TEST(Type, getAsText_Inheritance) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   Type Base;
   Base.setName("Base");
@@ -75,26 +73,25 @@ TEST(Type, getAsText_Inheritance) {
   TypeImport Inherit;
   Inherit.setIsInheritance();
   Inherit.setParent(&ParentClass);
-  EXPECT_EQ(Inherit.getAsText(), "  - private \"\"");
+  EXPECT_EQ(Inherit.getAsText(Settings), "  - private \"\"");
 
   // Test type name, no access, struct parent.
   Inherit.setType(&Base);
   Inherit.setParent(&ParentStruct);
-  EXPECT_EQ(Inherit.getAsText(), "  - public \"Base\"");
+  EXPECT_EQ(Inherit.getAsText(Settings), "  - public \"Base\"");
 
   // Test different access.
   Inherit.setParent(nullptr); // Parent should not be checked.
   Inherit.setInheritanceAccess(AccessSpecifier::Private);
-  EXPECT_EQ(Inherit.getAsText(), "  - private \"Base\"");
+  EXPECT_EQ(Inherit.getAsText(Settings), "  - private \"Base\"");
   Inherit.setInheritanceAccess(AccessSpecifier::Protected);
-  EXPECT_EQ(Inherit.getAsText(), "  - protected \"Base\"");
+  EXPECT_EQ(Inherit.getAsText(Settings), "  - protected \"Base\"");
   Inherit.setInheritanceAccess(AccessSpecifier::Public);
-  EXPECT_EQ(Inherit.getAsText(), "  - public \"Base\"");
+  EXPECT_EQ(Inherit.getAsText(Settings), "  - public \"Base\"");
 }
 
 TEST(Type, getAsText_Param) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   Type Ty;
   Ty.setName("wsx");
@@ -106,15 +103,17 @@ TEST(Type, getAsText_Param) {
   TyParam.setName("qaz");
   TyParam.setType(&Ty);
   TyParam.setIsTemplateType();
-  EXPECT_EQ(TyParam.getAsText(), "{TemplateParameter} \"qaz\" <- \"wsx\"");
+  EXPECT_EQ(TyParam.getAsText(Settings),
+            "{TemplateParameter} \"qaz\" <- \"wsx\"");
 
   Ty.setQualifiedName("base::");
   Ty.setHasQualifiedName();
-  EXPECT_EQ(TyParam.getAsText(), "{TemplateParameter} \"qaz\" <- \"base::wsx\"");
+  EXPECT_EQ(TyParam.getAsText(Settings),
+            "{TemplateParameter} \"qaz\" <- \"base::wsx\"");
 
   TyParam.setQualifiedName("base::");
   TyParam.setHasQualifiedName();
-  EXPECT_EQ(TyParam.getAsText(),
+  EXPECT_EQ(TyParam.getAsText(Settings),
             "{TemplateParameter} \"base::qaz\" <- \"base::wsx\"");
 
   // Template value.
@@ -122,14 +121,15 @@ TEST(Type, getAsText_Param) {
   TemplateValue.setIsTemplateValue();
   TemplateValue.setName("TVal");
   TemplateValue.setValue("101");
-  EXPECT_EQ(TemplateValue.getAsText(), "{TemplateParameter} \"TVal\" <- 101");
+  EXPECT_EQ(TemplateValue.getAsText(Settings),
+            "{TemplateParameter} \"TVal\" <- 101");
 
   // Template template.
   TypeParam TemplateTemplate;
   TemplateTemplate.setIsTemplateTemplate();
   TemplateTemplate.setName("TTemp");
   TemplateTemplate.setValue("vector");
-  EXPECT_EQ(TemplateTemplate.getAsText(),
+  EXPECT_EQ(TemplateTemplate.getAsText(Settings),
             "{TemplateParameter} \"TTemp\" <- \"vector\"");
 
   // Template packs print differently.
@@ -137,13 +137,10 @@ TEST(Type, getAsText_Param) {
   ScpTP.setIsScope();
   ScpTP.setIsTemplatePack();
   TyParam.setParent(&ScpTP);
-  EXPECT_EQ(TyParam.getAsText(), "<- \"base::wsx\"");
+  EXPECT_EQ(TyParam.getAsText(Settings), "<- \"base::wsx\"");
 }
 
 TEST(Type, getAsYAML_Param) {
-  Reader R;
-  setReader(&R);
-
   Type Ty;
   Ty.setName("Ty");
 
@@ -233,34 +230,30 @@ TEST(Type, getAsYAML_Param) {
 }
 
 TEST(Type, getAsText_PrimitiveType) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   Type Ty(/*level*/3);
   Ty.setIsBaseType();
   Ty.setIncludeInPrint();
 
-  EXPECT_EQ(Ty.getAsText(), "{PrimitiveType} -> \"\"");
+  EXPECT_EQ(Ty.getAsText(Settings), "{PrimitiveType} -> \"\"");
 
   Ty.setName("qaz");
-  EXPECT_EQ(Ty.getAsText(), "{PrimitiveType} -> \"qaz\"");
+  EXPECT_EQ(Ty.getAsText(Settings), "{PrimitiveType} -> \"qaz\"");
 
   // See Object::getAttributeInfoAsText() for why the indent is this size.
   std::string AttrIndent(3 + 4 + 8 + ((Ty.getLevel() + 1) * 2), ' ');
 
   Ty.setByteSize(4);
-  EXPECT_EQ(Ty.getAsText(), std::string("{PrimitiveType} -> \"qaz\"") +
+  EXPECT_EQ(Ty.getAsText(Settings), std::string("{PrimitiveType} -> \"qaz\"") +
     '\n' + AttrIndent + std::string("- 4 bytes"));
 
   Ty.setByteSize(23);
-  EXPECT_EQ(Ty.getAsText(), std::string("{PrimitiveType} -> \"qaz\"") +
+  EXPECT_EQ(Ty.getAsText(Settings), std::string("{PrimitiveType} -> \"qaz\"") +
     '\n' + AttrIndent + std::string("- 23 bytes"));
 }
 
 TEST(Type, getAsYAML_PrimitiveType) {
-  Reader R;
-  setReader(&R);
-
   Type Ty;
   Ty.setIsBaseType();
   Ty.setName("qaz");
@@ -284,31 +277,27 @@ TEST(Type, getAsYAML_PrimitiveType) {
 }
 
 TEST(Type, getAsText_Typedef) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   TypeDefinition TyDef(0);
   ASSERT_TRUE(TyDef.getIsPrintedAsObject());
   TyDef.setIsTypedef();
   TyDef.setIncludeInPrint();
 
-  EXPECT_EQ(TyDef.getAsText(), "{Alias} \"\" -> \"\"");
+  EXPECT_EQ(TyDef.getAsText(Settings), "{Alias} \"\" -> \"\"");
 
   TyDef.setName("qaz");
-  EXPECT_EQ(TyDef.getAsText(), "{Alias} \"qaz\" -> \"\"");
+  EXPECT_EQ(TyDef.getAsText(Settings), "{Alias} \"qaz\" -> \"\"");
 
   TypeDefinition TyDef2(0);
   TyDef2.setIsTypedef();
   TyDef2.setIncludeInPrint();
   TyDef2.setName("wsx");
   TyDef.setType(&TyDef2);
-  EXPECT_EQ(TyDef.getAsText(), "{Alias} \"qaz\" -> \"wsx\"");
+  EXPECT_EQ(TyDef.getAsText(Settings), "{Alias} \"qaz\" -> \"wsx\"");
 }
 
 TEST(Type, getAsYAML_Typedef) {
-  Reader R;
-  setReader(&R);
-
   TypeDefinition TD(0);
   TD.setIsTypedef();
   TD.setDieOffset(0x84);
@@ -333,8 +322,7 @@ TEST(Type, getAsYAML_Typedef) {
 }
 
 TEST(Type, getAsText_Using) {
-  Reader R;
-  setReader(&R);
+  PrintSettings Settings;
 
   Scope CU(0);
   CU.setIsCompileUnit();
@@ -346,7 +334,8 @@ TEST(Type, getAsText_Using) {
   NS.setName("test_name");
   NS.setParent(&CU);
   UsingNamespace.setType(&NS);
-  EXPECT_EQ(UsingNamespace.getAsText(), "{Using} namespace \"test_name\"");
+  EXPECT_EQ(UsingNamespace.getAsText(Settings),
+            "{Using} namespace \"test_name\"");
 
   TypeImport UsingType;
   UsingType.setIsImportedDeclaration();
@@ -354,12 +343,13 @@ TEST(Type, getAsText_Using) {
   Ty.setName("test_type");
   Ty.setParent(&CU);
   UsingType.setType(&Ty);
-  EXPECT_EQ(UsingType.getAsText(), "{Using} type \"test_type\"");
+  EXPECT_EQ(UsingType.getAsText(Settings), "{Using} type \"test_type\"");
 
   Scope Parent(0);
   Parent.setName("parent");
   Ty.setParent(&Parent);
-  EXPECT_EQ(UsingType.getAsText(), "{Using} type \"parent::test_type\"");
+  EXPECT_EQ(UsingType.getAsText(Settings),
+            "{Using} type \"parent::test_type\"");
 
   TypeImport UsingVariable;
   UsingVariable.setIsImportedDeclaration();
@@ -368,10 +358,11 @@ TEST(Type, getAsText_Using) {
   Variable.setName("test_variable");
   Variable.setParent(&CU);
   UsingVariable.setType(&Variable);
-  EXPECT_EQ(UsingVariable.getAsText(), "{Using} variable \"test_variable\"");
+  EXPECT_EQ(UsingVariable.getAsText(Settings),
+            "{Using} variable \"test_variable\"");
 
   Variable.setParent(&Parent);
-  EXPECT_EQ(UsingVariable.getAsText(),
+  EXPECT_EQ(UsingVariable.getAsText(Settings),
     "{Using} variable \"parent::test_variable\"");
 
   TypeImport UsingMember;
@@ -381,10 +372,11 @@ TEST(Type, getAsText_Using) {
   Member.setName("test_member");
   Member.setParent(&CU);
   UsingMember.setType(&Member);
-  EXPECT_EQ(UsingMember.getAsText(), "{Using} variable \"test_member\"");
+  EXPECT_EQ(UsingMember.getAsText(Settings),
+    "{Using} variable \"test_member\"");
 
   Member.setParent(&Parent);
-  EXPECT_EQ(UsingMember.getAsText(),
+  EXPECT_EQ(UsingMember.getAsText(Settings),
     "{Using} variable \"parent::test_member\"");
 
   TypeImport UsingFunction;
@@ -394,10 +386,11 @@ TEST(Type, getAsText_Using) {
   Func.setName("test_function");
   Func.setParent(&CU);
   UsingFunction.setType(&Func);
-  EXPECT_EQ(UsingFunction.getAsText(), "{Using} function \"test_function\"");
+  EXPECT_EQ(UsingFunction.getAsText(Settings),
+            "{Using} function \"test_function\"");
 
   Func.setParent(&Parent);
-  EXPECT_EQ(UsingFunction.getAsText(),
+  EXPECT_EQ(UsingFunction.getAsText(Settings),
     "{Using} function \"parent::test_function\"");
 
   TypeImport UsingStruct;
@@ -407,23 +400,21 @@ TEST(Type, getAsText_Using) {
   ScpStruct.setName("test_struct");
   ScpStruct.setParent(&CU);
   UsingStruct.setType(&ScpStruct);
-  EXPECT_EQ(UsingStruct.getAsText(), "{Using} type \"test_struct\"");
+  EXPECT_EQ(UsingStruct.getAsText(Settings), "{Using} type \"test_struct\"");
 
   ScpStruct.setParent(&Parent);
-  EXPECT_EQ(UsingStruct.getAsText(), "{Using} type \"parent::test_struct\"");
+  EXPECT_EQ(UsingStruct.getAsText(Settings),
+            "{Using} type \"parent::test_struct\"");
 
   // What if we have nested parents?
   Scope GrandParent(0);
   GrandParent.setName("grandparent");
   Parent.setParent(&GrandParent);
-  EXPECT_EQ(UsingFunction.getAsText(),
+  EXPECT_EQ(UsingFunction.getAsText(Settings),
     "{Using} function \"grandparent::parent::test_function\"");
 }
 
 TEST(Type, getAsYAML_Using) {
-  Reader R;
-  setReader(&R);
-
   Scope CU(0);
   CU.setIsCompileUnit();
   CU.setName("I should never be seen!");


### PR DESCRIPTION
This reduces global state, makes it easier to 'de-globalize' Reader in the future, and makes it easier to move text printing to the visitor style that YAML printing uses.

The change generally involves adding PrintSettings as parameters where they used to be accessed globally.