### PR TITLE
Don't store level for each object and remove dead tag code

### DIFF
--- a/DIVA/ElfDwarfReader/src/ElfDwarfReader.cpp
+++ b/DIVA/ElfDwarfReader/src/ElfDwarfReader.cpp
@@ -113,7 +113,7 @@ void writeStringOrHex(std::ostream &Out, const std::string Str,
 } // end anonymous namespace
 
 bool DwarfReader::createScopes() {
-  auto *Root = new LibScopeView::ScopeRoot(0U);
+  auto *Root = new LibScopeView::ScopeRoot;
   Root->setIsRoot();
   Root->setName(getInputFile().c_str());
   Scopes = Root;
@@ -145,7 +145,7 @@ void DwarfReader::createCompileUnits(const DwarfDebugData &DebugData,
     SourceFileMapping = getSourceFileMapping(DebugData, CU.CUDie);
 
     // Recursively create the tree of Objects from the CU and down.
-    createObject(DebugData, CU.CUDie, Root, 0U);
+    createObject(DebugData, CU.CUDie, Root);
   }
 
   // If we didn't skip any Dies (because of unknown tags) then we should have
@@ -158,8 +158,7 @@ void DwarfReader::createCompileUnits(const DwarfDebugData &DebugData,
 
 void DwarfReader::createObject(const DwarfDebugData &DebugData,
                                const DwarfDie &Die,
-                               LibScopeView::Object &ParentObj,
-                               LibScopeView::LevelType Level) {
+                               LibScopeView::Object &ParentObj) {
   // For now do nothing if the parent is not a scope.
   if (!ParentObj.getIsScope())
     return;
@@ -169,7 +168,7 @@ void DwarfReader::createObject(const DwarfDebugData &DebugData,
   auto ObjTag = Die.getTag();
 
   // Create the object from the DWARF tag.
-  LibScopeView::Object *Obj = createObjectByTag(ObjTag, Level);
+  LibScopeView::Object *Obj = createObjectByTag(ObjTag);
   if (!Obj)
     return;
 
@@ -203,208 +202,208 @@ void DwarfReader::createObject(const DwarfDebugData &DebugData,
 
   // Recurse on the DIE children.
   for (auto IT = Die.childrenBegin(), End = Die.childrenEnd(); IT != End; ++IT)
-    createObject(DebugData, *IT, *Obj, Level + 1);
+    createObject(DebugData, *IT, *Obj);
 }
 
 LibScopeView::Object *
-DwarfReader::createObjectByTag(Dwarf_Half Tag, LibScopeView::LevelType Level) {
+DwarfReader::createObjectByTag(Dwarf_Half Tag) {
   switch (Tag) {
   // Types.
   case DW_TAG_base_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsBaseType();
     return Obj;
   }
   case DW_TAG_const_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsConstType();
     return Obj;
   }
   case DW_TAG_enumerator: {
-    auto Obj = new LibScopeView::TypeEnumerator(Level);
+    auto Obj = new LibScopeView::TypeEnumerator;
     Obj->setIsEnumerator();
     return Obj;
   }
   case DW_TAG_imported_declaration: {
-    auto Obj = new LibScopeView::TypeImport(Level);
+    auto Obj = new LibScopeView::TypeImport;
     Obj->setIsImportedDeclaration();
     return Obj;
   }
   case DW_TAG_imported_module: {
-    auto Obj = new LibScopeView::TypeImport(Level);
+    auto Obj = new LibScopeView::TypeImport;
     Obj->setIsImportedModule();
     return Obj;
   }
   case DW_TAG_inheritance: {
-    auto Obj = new LibScopeView::TypeImport(Level);
+    auto Obj = new LibScopeView::TypeImport;
     Obj->setIsInheritance();
     return Obj;
   }
   case DW_TAG_pointer_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsPointerType();
     return Obj;
   }
   case DW_TAG_ptr_to_member_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsPointerMemberType();
     return Obj;
   }
   case DW_TAG_reference_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsReferenceType();
     return Obj;
   }
   case DW_TAG_restrict_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsRestrictType();
     return Obj;
   }
   case DW_TAG_rvalue_reference_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsRvalueReferenceType();
     return Obj;
   }
   case DW_TAG_subrange_type: {
-    auto Obj = new LibScopeView::TypeSubrange(Level);
+    auto Obj = new LibScopeView::TypeSubrange;
     Obj->setIsSubrangeType();
     return Obj;
   }
   case DW_TAG_template_value_parameter: {
-    auto Obj = new LibScopeView::TypeParam(Level);
+    auto Obj = new LibScopeView::TypeParam;
     Obj->setIsTemplateValue();
     return Obj;
   }
   case DW_TAG_template_type_parameter: {
-    auto Obj = new LibScopeView::TypeParam(Level);
+    auto Obj = new LibScopeView::TypeParam;
     Obj->setIsTemplateType();
     return Obj;
   }
   case DW_TAG_GNU_template_template_parameter: {
-    auto Obj = new LibScopeView::TypeParam(Level);
+    auto Obj = new LibScopeView::TypeParam;
     Obj->setIsTemplateTemplate();
     return Obj;
   }
   case DW_TAG_typedef: {
-    auto Obj = new LibScopeView::TypeDefinition(Level);
+    auto Obj = new LibScopeView::TypeDefinition;
     Obj->setIsTypedef();
     return Obj;
   }
   case DW_TAG_unspecified_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsUnspecifiedType();
     return Obj;
   }
   case DW_TAG_volatile_type: {
-    auto Obj = new LibScopeView::Type(Level);
+    auto Obj = new LibScopeView::Type;
     Obj->setIsVolatileType();
     return Obj;
   }
   // Symbols.
   case DW_TAG_formal_parameter: {
-    auto Obj = new LibScopeView::Symbol(Level);
+    auto Obj = new LibScopeView::Symbol;
     Obj->setIsParameter();
     return Obj;
   }
   case DW_TAG_unspecified_parameters: {
-    auto Obj = new LibScopeView::Symbol(Level);
+    auto Obj = new LibScopeView::Symbol;
     Obj->setIsUnspecifiedParameter();
     return Obj;
   }
   case DW_TAG_member: {
-    auto Obj = new LibScopeView::Symbol(Level);
+    auto Obj = new LibScopeView::Symbol;
     Obj->setIsMember();
     return Obj;
   }
   case DW_TAG_variable: {
-    auto Obj = new LibScopeView::Symbol(Level);
+    auto Obj = new LibScopeView::Symbol;
     Obj->setIsVariable();
     return Obj;
   }
   // Scopes.
   case DW_TAG_catch_block: {
-    auto Obj = new LibScopeView::Scope(Level);
+    auto Obj = new LibScopeView::Scope;
     Obj->setIsCatchBlock();
     return Obj;
   }
   case DW_TAG_lexical_block: {
-    auto Obj = new LibScopeView::Scope(Level);
+    auto Obj = new LibScopeView::Scope;
     Obj->setIsLexicalBlock();
     return Obj;
   }
   case DW_TAG_try_block: {
-    auto Obj = new LibScopeView::Scope(Level);
+    auto Obj = new LibScopeView::Scope;
     Obj->setIsTryBlock();
     return Obj;
   }
   case DW_TAG_compile_unit: {
-    auto Obj = new LibScopeView::ScopeCompileUnit(0);
+    auto Obj = new LibScopeView::ScopeCompileUnit;
     Obj->setIsCompileUnit();
     return Obj;
   }
   case DW_TAG_inlined_subroutine: {
-    auto Obj = new LibScopeView::ScopeFunctionInlined(Level);
+    auto Obj = new LibScopeView::ScopeFunctionInlined;
     Obj->setIsInlinedSubroutine();
     return Obj;
   }
   case DW_TAG_namespace: {
-    auto Obj = new LibScopeView::ScopeNamespace(Level);
+    auto Obj = new LibScopeView::ScopeNamespace;
     Obj->setIsNamespace();
     return Obj;
   }
   case DW_TAG_template_alias: {
-    auto Obj = new LibScopeView::ScopeAlias(Level);
+    auto Obj = new LibScopeView::ScopeAlias;
     Obj->setIsTemplateAlias();
     Obj->setIsTemplate();
     return Obj;
   }
   case DW_TAG_array_type: {
-    auto Obj = new LibScopeView::ScopeArray(Level);
+    auto Obj = new LibScopeView::ScopeArray;
     Obj->setIsArrayType();
     return Obj;
   }
   case DW_TAG_entry_point: {
-    auto Obj = new LibScopeView::ScopeFunction(Level);
+    auto Obj = new LibScopeView::ScopeFunction;
     Obj->setIsEntryPoint();
     return Obj;
   }
   case DW_TAG_subprogram: {
-    auto Obj = new LibScopeView::ScopeFunction(Level);
+    auto Obj = new LibScopeView::ScopeFunction;
     Obj->setIsSubprogram();
     return Obj;
   }
   case DW_TAG_subroutine_type: {
-    auto Obj = new LibScopeView::ScopeFunction(Level);
+    auto Obj = new LibScopeView::ScopeFunction;
     Obj->setIsSubroutineType();
     return Obj;
   }
   case DW_TAG_label: {
-    auto Obj = new LibScopeView::ScopeFunction(Level);
+    auto Obj = new LibScopeView::ScopeFunction;
     Obj->setIsLabel();
     return Obj;
   }
   case DW_TAG_class_type: {
-    auto Obj = new LibScopeView::ScopeAggregate(Level);
+    auto Obj = new LibScopeView::ScopeAggregate;
     Obj->setIsClassType();
     return Obj;
   }
   case DW_TAG_structure_type: {
-    auto Obj = new LibScopeView::ScopeAggregate(Level);
+    auto Obj = new LibScopeView::ScopeAggregate;
     Obj->setIsStructType();
     return Obj;
   }
   case DW_TAG_union_type: {
-    auto Obj = new LibScopeView::ScopeAggregate(Level);
+    auto Obj = new LibScopeView::ScopeAggregate;
     Obj->setIsUnionType();
     return Obj;
   }
   case DW_TAG_enumeration_type: {
-    auto Obj = new LibScopeView::ScopeEnumeration(Level);
+    auto Obj = new LibScopeView::ScopeEnumeration;
     Obj->setIsEnumerationType();
     return Obj;
   }
   case DW_TAG_GNU_template_parameter_pack: {
-    auto Obj = new LibScopeView::ScopeTemplatePack(Level);
+    auto Obj = new LibScopeView::ScopeTemplatePack;
     Obj->setIsTemplatePack();
     return Obj;
   }
@@ -577,7 +576,7 @@ void DwarfReader::createLines(const DwarfDie &CUDie,
 
   for (size_t LineIndex = 0; LineIndex < LineTable.size(); ++LineIndex) {
     auto DwarfLine = LineTable[LineIndex];
-    auto *Ln = new LibScopeView::Line(1U);
+    auto *Ln = new LibScopeView::Line;
 
     Ln->setIsLineRecord();
     CUObj.addObject(Ln);

--- a/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
+++ b/DIVA/ElfDwarfReader/src/ElfDwarfReader.h
@@ -64,13 +64,11 @@ private:
   /// Create a LibScopeView::Object from a Die and then recursivly create its
   /// children.
   void createObject(const DwarfDebugData &DebugData, const DwarfDie &Die,
-                    LibScopeView::Object &ParentObj,
-                    LibScopeView::LevelType Level);
+                    LibScopeView::Object &ParentObj);
 
   /// Create the appropriate subclass of LibScopeView::Object for the given
   /// DWARF tag.
-  LibScopeView::Object *createObjectByTag(Dwarf_Half Tag,
-                                          LibScopeView::LevelType Level);
+  LibScopeView::Object *createObjectByTag(Dwarf_Half Tag);
 
   /// setup the objects state from attributes on the DWARF Die.
   void initObjectFromAttrs(LibScopeView::Object &Obj, const DwarfDie &Die,

--- a/DIVA/LibScopeView/src/Line.cpp
+++ b/DIVA/LibScopeView/src/Line.cpp
@@ -35,36 +35,13 @@
 
 using namespace LibScopeView;
 
-Line::Line(LevelType Lvl) : Element(Lvl), Discriminator(0) {
-  setIsLine();
-
-  Line::setTag();
-}
-
 Line::Line() : Element(), Discriminator(0) {
   setIsLine();
-
-  Line::setTag();
 }
 
 Line::~Line() {}
 
 uint32_t Line::LinesAllocated = 0;
-
-void Line::setTag() {
-  ++Line::LinesAllocated;
-#ifndef NDEBUG
-  Tag = Line::LinesAllocated;
-#endif
-}
-
-uint32_t Line::getTag() const {
-#ifndef NDEBUG
-  return Tag;
-#else
-  return 0;
-#endif
-}
 
 // Line Kind.
 const char *Line::KindBasicBlock = "BasicBlock";

--- a/DIVA/LibScopeView/src/Line.h
+++ b/DIVA/LibScopeView/src/Line.h
@@ -40,7 +40,6 @@ namespace LibScopeView {
 class Line : public Element {
 public:
   Line();
-  Line(LevelType Lvl);
   virtual ~Line() override;
 
   Line &operator=(const Line &) = delete;
@@ -141,8 +140,6 @@ private:
 
 public:
   static uint32_t getInstanceCount() { return LinesAllocated; }
-  uint32_t getTag() const override;
-  void setTag() override;
 };
 
 } // namespace LibScopeView

--- a/DIVA/LibScopeView/src/Object.cpp
+++ b/DIVA/LibScopeView/src/Object.cpp
@@ -76,42 +76,14 @@ void LibScopeView::printAllocationInfo(std::ostream &Out) {
 // Class to represent the logical view of an object.
 //===----------------------------------------------------------------------===//
 
-Object::Object(LevelType Lvl) {
-  commonConstructor();
-
-  Level = Lvl;
-}
-
-Object::Object() { commonConstructor(); }
-
-Object::~Object() {}
-
-void Object::commonConstructor() {
-
+Object::Object() {
   LineNumber = 0;
   Parent = nullptr;
-  Level = 0;
   DieOffset = 0;
   DieTag = 0;
-
-#ifndef NDEBUG
-  Tag = 0;
-#endif
 }
 
-void Object::setTag() {
-#ifndef NDEBUG
-  Tag = 0;
-#endif
-}
-
-uint32_t Object::getTag() const {
-#ifndef NDEBUG
-  return Tag;
-#else
-  return 0;
-#endif
-}
+Object::~Object() {}
 
 namespace {
 
@@ -175,13 +147,6 @@ void Object::resolveQualifiedName(const Scope *ExplicitParent) {
     setQualifiedName(QualifiedName.c_str());
     setHasQualifiedName();
   }
-}
-
-std::string Object::getIndentString(const PrintSettings &Settings) const {
-  // No indent for root.
-  if (getLevel() == 0 && getIsScope() && getParent() == nullptr)
-    return "";
-  return Settings.ShowIndent ? std::string((getLevel() + 1) * 2, ' ') : "";
 }
 
 bool Object::setFullName(const PrintSettings &Settings, Type *BaseType,
@@ -408,11 +373,7 @@ std::string Object::getCommonYAML() const {
 //===----------------------------------------------------------------------===//
 // Class to represent the basic data for an object.
 //===----------------------------------------------------------------------===//
-Element::Element(LevelType level) : Object(level) { CommonConstructor(); }
-
-Element::Element() : Object() { CommonConstructor(); }
-
-void Element::CommonConstructor() {
+Element::Element() : Object() {
   NameIndex = 0;
   QualifiedIndex = 0;
   FilenameIndex = 0;

--- a/DIVA/LibScopeView/src/Object.h
+++ b/DIVA/LibScopeView/src/Object.h
@@ -55,8 +55,6 @@ class Type;
 
 void printAllocationInfo(std::ostream &Out);
 
-typedef uint16_t LevelType;
-
 /// \brief Enum to represent C++ access specifiers.
 enum class AccessSpecifier { Unspecified, Private, Protected, Public };
 
@@ -64,14 +62,10 @@ enum class AccessSpecifier { Unspecified, Private, Protected, Public };
 class Object {
 public:
   Object();
-  Object(LevelType Lvl);
   virtual ~Object();
 
   Object(const Object &) = delete;
   Object &operator=(const Object &) = delete;
-
-private:
-  void commonConstructor();
 
 private:
   // Flags specifying various properties of the Object.
@@ -145,9 +139,6 @@ public:
   void setHasQualifiedName() { ObjectAttributesFlags.set(HasQualifiedName); }
 
 protected:
-  // Scope level for this object.
-  LevelType Level;
-
   // Line associated with this object.
   uint64_t LineNumber;
 
@@ -221,11 +212,6 @@ public:
   virtual Dwarf_Half getDiscriminator() const { return 0; }
   virtual void setDiscriminator(Dwarf_Half /*Discriminator*/) {}
 
-  /// \brief The level where this object is located.
-  LevelType getLevel() const { return Level; }
-  void setLevel(LevelType Lvl) { Level = Lvl; }
-  std::string getIndentString(const PrintSettings &Settings) const;
-
   /// \brief The parent scope for this object.
   Scope *getParent() const { return Parent; }
   void setParent(Scope *ObjParent) { Parent = ObjParent; }
@@ -252,9 +238,6 @@ public:
                    const char *BaseText = nullptr);
 
 public:
-  virtual uint32_t getTag() const;
-  virtual void setTag();
-
   /// \brief Should this object be printed under children?
   virtual bool getIsPrintedAsObject() const { return true; }
   /// \brief Returns a text representation of this DIVA Object.
@@ -267,25 +250,16 @@ protected:
   static std::string formatAttributeText(const std::string &AttributeText);
   /// \brief Returns the common YAML information for this object.
   std::string getCommonYAML() const;
-
-#ifndef NDEBUG
-protected:
-  uint32_t Tag;
-#endif
 };
 
 /// \brief Class to represent the basic data for an object.
 class Element : public Object {
 public:
   Element();
-  Element(LevelType Lvl);
   virtual ~Element() override {}
 
   Element &operator=(const Element &) = delete;
   Element(const Element &) = delete;
-
-private:
-  void CommonConstructor();
 
 protected:
   // The name, type name, qualified name and filename in String Pool.

--- a/DIVA/LibScopeView/src/Scope.cpp
+++ b/DIVA/LibScopeView/src/Scope.cpp
@@ -40,16 +40,8 @@
 
 using namespace LibScopeView;
 
-Scope::Scope(LevelType Lvl) : Element(Lvl) {
-  setIsScope();
-
-  Scope::setTag();
-}
-
 Scope::Scope() : Element() {
   setIsScope();
-
-  Scope::setTag();
 }
 
 Scope::~Scope() {
@@ -64,21 +56,6 @@ Scope::~Scope() {
 }
 
 uint32_t Scope::ScopesAllocated = 0;
-
-void Scope::setTag() {
-  ++Scope::ScopesAllocated;
-#ifndef NDEBUG
-  Tag = Scope::ScopesAllocated;
-#endif
-}
-
-uint32_t Scope::getTag() const {
-#ifndef NDEBUG
-  return Tag;
-#else
-  return 0;
-#endif
-}
 
 // Scope Kind.
 const char *Scope::KindAggregate = "Aggregate";
@@ -254,10 +231,6 @@ std::string Scope::getAsYAML() const {
   return "";
 }
 
-ScopeAggregate::ScopeAggregate(LevelType Lvl) : Scope(Lvl) {
-  Reference = nullptr;
-}
-
 ScopeAggregate::ScopeAggregate() : Scope() { Reference = nullptr; }
 
 ScopeAggregate::~ScopeAggregate() {}
@@ -312,8 +285,6 @@ std::string ScopeAggregate::getAsYAML() const {
   return Result.str();
 }
 
-ScopeAlias::ScopeAlias(LevelType Lvl) : Scope(Lvl) {}
-
 ScopeAlias::ScopeAlias() : Scope() {}
 
 ScopeAlias::~ScopeAlias() {}
@@ -330,8 +301,6 @@ std::string ScopeAlias::getAsYAML() const {
   return getCommonYAML() + std::string("\nattributes: {}");
 }
 
-ScopeArray::ScopeArray(LevelType Lvl) : Scope(Lvl) {}
-
 ScopeArray::ScopeArray() : Scope() {}
 
 ScopeArray::~ScopeArray() {}
@@ -342,8 +311,6 @@ std::string ScopeArray::getAsText(const PrintSettings &Settings) const {
          << getTypeDieOffsetAsString(Settings) << '"' << getName() << '"';
   return Result.str();
 }
-
-ScopeCompileUnit::ScopeCompileUnit(LevelType Lvl) : Scope(Lvl) {}
 
 ScopeCompileUnit::ScopeCompileUnit() : Scope() {}
 
@@ -365,9 +332,6 @@ std::string ScopeCompileUnit::getAsText(const PrintSettings &) const {
 std::string ScopeCompileUnit::getAsYAML() const {
   return getCommonYAML() + std::string("\nattributes: {}");
 }
-
-ScopeEnumeration::ScopeEnumeration(LevelType Lvl)
-    : Scope(Lvl), IsClass(false) {}
 
 ScopeEnumeration::ScopeEnumeration() : Scope(), IsClass(false) {}
 
@@ -421,11 +385,6 @@ std::string ScopeEnumeration::getAsYAML() const {
     YAML << Enumerators.str();
 
   return YAML.str();
-}
-
-ScopeFunction::ScopeFunction(LevelType Lvl)
-    : Scope(Lvl), IsStatic(false), DeclaredInline(false), IsDeclaration(false) {
-  Reference = nullptr;
 }
 
 ScopeFunction::ScopeFunction()
@@ -524,21 +483,12 @@ std::string ScopeFunction::getAsYAML() const {
   return YAML.str();
 }
 
-ScopeFunctionInlined::ScopeFunctionInlined(LevelType Lvl)
-    : ScopeFunction(Lvl), CallLineNumber(0) {
-  Discriminator = 0;
-}
-
 ScopeFunctionInlined::ScopeFunctionInlined()
     : ScopeFunction(), CallLineNumber(0) {
   Discriminator = 0;
 }
 
 ScopeFunctionInlined::~ScopeFunctionInlined() {}
-
-ScopeNamespace::ScopeNamespace(LevelType Lvl) : Scope(Lvl) {
-  Reference = nullptr;
-}
 
 ScopeNamespace::ScopeNamespace() : Scope() { Reference = nullptr; }
 
@@ -557,8 +507,6 @@ std::string ScopeNamespace::getAsText(const PrintSettings &) const {
 std::string ScopeNamespace::getAsYAML() const {
   return getCommonYAML() + std::string("\nattributes: {}");
 }
-
-ScopeTemplatePack::ScopeTemplatePack(LevelType Lvl) : Scope(Lvl) {}
 
 ScopeTemplatePack::ScopeTemplatePack() : Scope() {}
 
@@ -605,8 +553,6 @@ std::string ScopeTemplatePack::getAsYAML() const {
 
   return YAML.str();
 }
-
-ScopeRoot::ScopeRoot(LevelType Lvl) : Scope(Lvl) {}
 
 ScopeRoot::ScopeRoot() : Scope() {}
 

--- a/DIVA/LibScopeView/src/Scope.h
+++ b/DIVA/LibScopeView/src/Scope.h
@@ -45,7 +45,6 @@ class Scope : public Element {
 
 public:
   Scope();
-  Scope(LevelType Lvl);
   virtual ~Scope() override;
 
   Scope &operator=(const Scope &) = delete;
@@ -345,15 +344,12 @@ private:
 
 public:
   static uint32_t getInstanceCount() { return ScopesAllocated; }
-  uint32_t getTag() const override;
-  void setTag() override;
 };
 
 /// \brief Class to represent a DWARF Union/Structure/Class object.
 class ScopeAggregate : public Scope {
 public:
   ScopeAggregate();
-  ScopeAggregate(LevelType Lvl);
   virtual ~ScopeAggregate() override;
 
   ScopeAggregate &operator=(const ScopeAggregate &) = delete;
@@ -381,7 +377,6 @@ public:
 class ScopeAlias : public Scope {
 public:
   ScopeAlias();
-  ScopeAlias(LevelType Lvl);
   virtual ~ScopeAlias() override;
 
   ScopeAlias &operator=(const ScopeAlias &) = delete;
@@ -398,7 +393,6 @@ public:
 class ScopeArray : public Scope {
 public:
   ScopeArray();
-  ScopeArray(LevelType Lvl);
   virtual ~ScopeArray() override;
 
   ScopeArray &operator=(const ScopeArray &) = delete;
@@ -414,7 +408,6 @@ public:
 class ScopeCompileUnit : public Scope {
 public:
   ScopeCompileUnit();
-  ScopeCompileUnit(LevelType Lvl);
   virtual ~ScopeCompileUnit() override;
 
   ScopeCompileUnit &operator=(const ScopeCompileUnit &) = delete;
@@ -436,7 +429,6 @@ public:
 class ScopeEnumeration : public Scope {
 public:
   ScopeEnumeration();
-  ScopeEnumeration(LevelType Lvl);
   virtual ~ScopeEnumeration() override;
 
   ScopeEnumeration &operator=(const ScopeEnumeration &) = delete;
@@ -459,7 +451,6 @@ private:
 class ScopeFunction : public Scope {
 public:
   ScopeFunction();
-  ScopeFunction(LevelType Lvl);
   virtual ~ScopeFunction() override;
 
   ScopeFunction &operator=(const ScopeFunction &) = delete;
@@ -502,7 +493,6 @@ public:
 class ScopeFunctionInlined : public ScopeFunction {
 public:
   ScopeFunctionInlined();
-  ScopeFunctionInlined(LevelType Lvl);
   virtual ~ScopeFunctionInlined() override;
 
   ScopeFunctionInlined &operator=(const ScopeFunctionInlined &) = delete;
@@ -535,7 +525,6 @@ public:
 class ScopeNamespace : public Scope {
 public:
   ScopeNamespace();
-  ScopeNamespace(LevelType Lvl);
   virtual ~ScopeNamespace() override;
 
   ScopeNamespace &operator=(const ScopeNamespace &) = delete;
@@ -566,7 +555,6 @@ public:
 class ScopeTemplatePack : public Scope {
 public:
   ScopeTemplatePack();
-  ScopeTemplatePack(LevelType Lvl);
   virtual ~ScopeTemplatePack() override;
 
   ScopeTemplatePack &operator=(const ScopeTemplatePack &) = delete;
@@ -583,7 +571,6 @@ public:
 class ScopeRoot : public Scope {
 public:
   ScopeRoot();
-  ScopeRoot(LevelType Lvl);
   virtual ~ScopeRoot() override;
 
   ScopeRoot &operator=(const ScopeRoot &) = delete;

--- a/DIVA/LibScopeView/src/ScopeTextPrinter.h
+++ b/DIVA/LibScopeView/src/ScopeTextPrinter.h
@@ -54,7 +54,8 @@ private:
 
   std::string HeaderText;
   const uint8_t IndentSize;
-  uint32_t IndentLevel = 1;
+  size_t CurrentLevel = 0;
+  size_t IndentLevel = 1;
   size_t CurrentFileIndex = 0;
 
   // Indent sizes calculated from the tree being printed.

--- a/DIVA/LibScopeView/src/Symbol.cpp
+++ b/DIVA/LibScopeView/src/Symbol.cpp
@@ -36,41 +36,15 @@
 
 using namespace LibScopeView;
 
-Symbol::Symbol(LevelType Lvl)
-    : Element(Lvl), TheAccessSpecifier(AccessSpecifier::Unspecified),
-      IsStatic(false), Reference(nullptr) {
-  setIsSymbol();
-
-  Symbol::setTag();
-}
-
 Symbol::Symbol()
     : Element(), TheAccessSpecifier(AccessSpecifier::Unspecified),
       IsStatic(false), Reference(nullptr) {
   setIsSymbol();
-
-  Symbol::setTag();
 }
 
 Symbol::~Symbol() {}
 
 uint32_t Symbol::SymbolsAllocated = 0;
-
-// Set Unique Object identifier, for debug purposes
-void Symbol::setTag() {
-  ++Symbol::SymbolsAllocated;
-#ifndef NDEBUG
-  Tag = Symbol::SymbolsAllocated;
-#endif
-}
-
-uint32_t Symbol::getTag() const {
-#ifndef NDEBUG
-  return Tag;
-#else
-  return 0;
-#endif
-}
 
 // Symbol Kind.
 const char *Symbol::KindMember = "Member";

--- a/DIVA/LibScopeView/src/Symbol.h
+++ b/DIVA/LibScopeView/src/Symbol.h
@@ -38,7 +38,6 @@ namespace LibScopeView {
 class Symbol : public Element {
 public:
   Symbol();
-  Symbol(LevelType Lvl);
   virtual ~Symbol() override;
 
   Symbol &operator=(const Symbol &) = delete;
@@ -123,8 +122,6 @@ private:
 
 public:
   static uint32_t getInstanceCount() { return SymbolsAllocated; }
-  uint32_t getTag() const override;
-  void setTag() override;
 };
 
 } // namespace LibScopeView

--- a/DIVA/LibScopeView/src/Type.cpp
+++ b/DIVA/LibScopeView/src/Type.cpp
@@ -38,36 +38,13 @@
 
 using namespace LibScopeView;
 
-Type::Type(LevelType Lvl) : Element(Lvl), ByteSize(0) {
-  setIsType();
-
-  Type::setTag();
-}
-
 Type::Type() : ByteSize(0) {
   setIsType();
-
-  Type::setTag();
 }
 
 Type::~Type() {}
 
 uint32_t Type::TypesAllocated = 0;
-
-void Type::setTag() {
-  ++Type::TypesAllocated;
-#ifndef NDEBUG
-  Tag = Type::TypesAllocated;
-#endif
-}
-
-uint32_t Type::getTag() const {
-#ifndef NDEBUG
-  return Tag;
-#else
-  return 0;
-#endif
-}
 
 // Type Kind.
 const char *Type::KindBase = "PrimitiveType";
@@ -195,9 +172,6 @@ unsigned Type::getByteSize() const { return ByteSize; }
 
 void Type::setByteSize(unsigned Size) { ByteSize = Size; }
 
-/// \brief Class to represent a DWARF typedef object.
-TypeDefinition::TypeDefinition(LevelType Lvl) : Type(Lvl) {}
-
 TypeDefinition::TypeDefinition() : Type() {}
 
 TypeDefinition::~TypeDefinition() {}
@@ -243,9 +217,6 @@ std::string TypeDefinition::getAsYAML() const {
   return getCommonYAML() + std::string("\nattributes: {}");
 }
 
-/// \brief Class to represent a DWARF enumerator (DW_TAG_enumerator).
-TypeEnumerator::TypeEnumerator(LevelType Lvl) : Type(Lvl) { ValueIndex = 0; }
-
 TypeEnumerator::TypeEnumerator() : Type() { ValueIndex = 0; }
 
 TypeEnumerator::~TypeEnumerator() {}
@@ -276,10 +247,6 @@ std::string TypeEnumerator::getAsYAML() const {
   // Printing enumerators is handled in ScopeEnumeration.
   return "";
 }
-
-/// \brief Class to represent a DWARF Import object (Using).
-TypeImport::TypeImport(LevelType Lvl)
-    : Type(Lvl), InheritanceAccess(AccessSpecifier::Unspecified) {}
 
 TypeImport::TypeImport()
     : Type(), InheritanceAccess(AccessSpecifier::Unspecified) {}
@@ -463,8 +430,6 @@ std::string TypeImport::getUsingAsYAML() const {
   return Result.str();
 }
 
-TypeParam::TypeParam(LevelType Lvl) : Type(Lvl) { ValueIndex = 0; }
-
 TypeParam::TypeParam() : Type() { ValueIndex = 0; }
 
 TypeParam::~TypeParam() {}
@@ -533,8 +498,6 @@ std::string TypeParam::getAsYAML() const {
 
   return YAML.str();
 }
-
-TypeSubrange::TypeSubrange(LevelType Lvl) : Type(Lvl) {}
 
 TypeSubrange::TypeSubrange() : Type() {}
 

--- a/DIVA/LibScopeView/src/Type.h
+++ b/DIVA/LibScopeView/src/Type.h
@@ -37,7 +37,6 @@ namespace LibScopeView {
 class Type : public Element {
 public:
   Type();
-  Type(LevelType Lvl);
   virtual ~Type() override;
 
   Type &operator=(const Type &) = delete;
@@ -218,8 +217,6 @@ private:
 
 public:
   static uint32_t getInstanceCount() { return TypesAllocated; }
-  uint32_t getTag() const override;
-  void setTag() override;
 
 private:
   // DW_AT_byte_size for PrimitiveType.
@@ -234,7 +231,6 @@ public:
 class TypeDefinition : public Type {
 public:
   TypeDefinition();
-  TypeDefinition(LevelType Lvl);
   virtual ~TypeDefinition() override;
 
   TypeDefinition &operator=(const TypeDefinition &) = delete;
@@ -259,7 +255,6 @@ public:
 class TypeEnumerator : public Type {
 public:
   TypeEnumerator();
-  TypeEnumerator(LevelType Lvl);
   virtual ~TypeEnumerator() override;
 
   TypeEnumerator &operator=(const TypeEnumerator &) = delete;
@@ -287,7 +282,6 @@ public:
 class TypeImport : public Type {
 public:
   TypeImport();
-  TypeImport(LevelType Lvl);
   virtual ~TypeImport() override;
 
   TypeImport &operator=(const TypeImport &) = delete;
@@ -323,7 +317,6 @@ private:
 class TypeParam : public Type {
 public:
   TypeParam();
-  TypeParam(LevelType Lvl);
   virtual ~TypeParam() override;
 
   TypeParam &operator=(const TypeParam &) = delete;
@@ -351,7 +344,6 @@ public:
 class TypeSubrange : public Type {
 public:
   TypeSubrange();
-  TypeSubrange(LevelType Lvl);
   virtual ~TypeSubrange() override;
 
   TypeSubrange &operator=(const TypeSubrange &) = delete;

--- a/DIVA/UnitTests/src/TestLibScopeView/TestLine.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestLine.cpp
@@ -35,7 +35,7 @@
 using namespace LibScopeView;
 
 TEST(Line, getAsText_Line) {
-  Line Ln(0);
+  Line Ln;
   Ln.setIsLineRecord();
   EXPECT_EQ(Ln.getAsText(PrintSettings()), "{CodeLine}");
 }
@@ -69,7 +69,7 @@ TEST(Line, getAsText_Line_Attributes) {
   PrintSettings Settings;
   Settings.ShowCodelineAttributes = true;
 
-  Line Ln(/*level*/ 3);
+  Line Ln;
   Ln.setIsLineRecord();
 
   Ln.setIsNewStatement();

--- a/DIVA/UnitTests/src/TestLibScopeView/TestScope.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestScope.cpp
@@ -112,16 +112,16 @@ TEST(Scope, getAsText_Block) {
   PrintSettings Settings;
   Settings.ShowBlockAttributes = true;
 
-  Scope Block(/*Level*/ 3);
+  Scope Block;
   Block.setIsBlock();
   EXPECT_EQ(Block.getAsText(Settings), "{Block}");
 
-  Scope TryBlock(/*Level*/ 3);
+  Scope TryBlock;
   TryBlock.setIsBlock();
   TryBlock.setIsTryBlock();
   EXPECT_EQ(TryBlock.getAsText(Settings), "{Block}\n    - try");
 
-  Scope CatchBlock(/*Level*/ 3);
+  Scope CatchBlock;
   CatchBlock.setIsBlock();
   CatchBlock.setIsCatchBlock();
   EXPECT_EQ(CatchBlock.getAsText(Settings), "{Block}\n    - catch");
@@ -428,7 +428,7 @@ TEST(Scope, getAsYAML_Enumeration) {
 TEST(Scope, getAsText_Function) {
   PrintSettings Settings;
 
-  ScopeFunction ScpFunc(0);
+  ScopeFunction ScpFunc;
   ScpFunc.setIsScope();
   ScpFunc.setIsFunction();
 
@@ -443,7 +443,7 @@ TEST(Scope, getAsText_Function) {
   EXPECT_EQ(ScpFunc.getAsText(Settings), "{Function} \"qaz\" -> \"\"\n"
                                          "    - No declaration");
 
-  Type RetType(0);
+  Type RetType;
   RetType.setName("wsx");
   ScpFunc.setType(&RetType);
   EXPECT_EQ(ScpFunc.getAsText(Settings), "{Function} \"qaz\" -> \"wsx\"\n"
@@ -454,7 +454,7 @@ TEST(Scope, getAsText_Function) {
   NS.setName("TestNamespace");
   ScpFunc.setParent(&NS);
   ScpFunc.resolveName();
-  EXPECT_EQ(ScpFunc.getAsText(Settings), 
+  EXPECT_EQ(ScpFunc.getAsText(Settings),
             "{Function} \"TestNamespace::qaz\" -> \"wsx\"\n"
             "    - No declaration");
 
@@ -484,7 +484,7 @@ TEST(Scope, getAsText_Function) {
             "{Function} inline \"dif\" -> \"\"\n"
             "    - No declaration");
 
-  ScopeFunction ScpQualFunc(0);
+  ScopeFunction ScpQualFunc;
   ScpQualFunc.setIsScope();
   ScpQualFunc.setIsFunction();
   ScpQualFunc.setName("qaz");
@@ -550,7 +550,7 @@ TEST(Scope, getAsText_Function_Attributes) {
   EXPECT_EQ(Func.getAsText(Settings), Expected);
 
   // ScopeFunctionInlined.
-  ScopeFunctionInlined inlined(0);
+  ScopeFunctionInlined inlined;
   inlined.setIsInlinedSubroutine();
   inlined.setName("Foo");
   EXPECT_EQ(inlined.getAsText(Settings), "{Function} \"Foo\" -> \"\"\n"
@@ -559,7 +559,7 @@ TEST(Scope, getAsText_Function_Attributes) {
 }
 
 TEST(Scope, getAsYAML_Function) {
-  ScopeFunction Func(0);
+  ScopeFunction Func;
   Func.setIsScope();
   Func.setIsFunction();
   Func.setName("Foo");
@@ -589,7 +589,7 @@ TEST(Scope, getAsYAML_Function) {
                               "  is_inlined: false\n"
                               "  is_declaration: false");
 
-  Type Ty(0);
+  Type Ty;
   Ty.setName("int");
   Func.setType(&Ty);
   EXPECT_EQ(Func.getAsYAML(), "object: \"Function\"\n"
@@ -677,7 +677,7 @@ TEST(Scope, getAsYAML_Function) {
                               "  is_declaration: true");
 
   // Function to be used as Reference.
-  ScopeFunction Reference(0);
+  ScopeFunction Reference;
   Reference.setIsScope();
   Reference.setIsFunction();
   Reference.setName("Ref");
@@ -729,7 +729,7 @@ TEST(Scope, getAsYAML_Function) {
                               "  is_declaration: true");
 
   // ScopeFunctionInlined.
-  ScopeFunctionInlined Inlined(0);
+  ScopeFunctionInlined Inlined;
   Inlined.setIsInlinedSubroutine();
   Inlined.setName("Foo");
   Inlined.setDieOffset(0x100);

--- a/DIVA/UnitTests/src/TestLibScopeView/TestScopeTextPrinter.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestScopeTextPrinter.cpp
@@ -317,10 +317,6 @@ TEST(ScopeTextPrinter, PrintDWARFAttributes) {
   Child1->setDieOffset(0x11);
   Child2->setDieOffset(0x11111111);
 
-  Top->setLevel(1);
-  Child1->setLevel(2);
-  Child2->setLevel(222);
-
   Top->setDieTag(DW_TAG_compile_unit);
   Child1->setDieTag(DW_TAG_namespace);
   Child2->setDieTag(DW_TAG_enumeration_type);
@@ -355,14 +351,14 @@ TEST(ScopeTextPrinter, PrintDWARFAttributes) {
   Settings.ShowDWARFParent = false;
   Settings.ShowLevel = true;
   ScopeTextPrinter(Settings, "In.o").print(&Root, Output);
-  EXPECT_EQ(Output.str(), "      {InputFile} \"In.o\"\n\n"
-                          "      {Source} \"foo.cpp\"\n"
-                          "001     11  {Fake} Top\n"
+  EXPECT_EQ(Output.str(), "    {InputFile} \"In.o\"\n\n"
+                          "    {Source} \"foo.cpp\"\n"
+                          "0     11  {Fake} Top\n"
+                          "            - Attr\n"
+                          "1    111    {Fake} Child1\n"
                           "              - Attr\n"
-                          "002    111    {Fake} Child1\n"
-                          "                - Attr\n"
-                          "222   1122    {Fake} Child2\n"
-                          "                - Attr\n");
+                          "1   1122    {Fake} Child2\n"
+                          "              - Attr\n");
 
   Output.str("");
   Settings.ShowLevel = false;
@@ -383,22 +379,17 @@ TEST(ScopeTextPrinter, PrintDWARFAttributes) {
   Settings.ShowLevel = true;
   Settings.ShowDWARFTag = true;
   ScopeTextPrinter(Settings, "In.o").print(&Root, Output);
+  // clang-format off
   std::string Expected(
-      "                                                       {InputFile} "
-      "\"In.o\"\n\n"
-      "                                                       {Source} "
-      "\"foo.cpp\"\n"
-      "[0x00001234][0x00000000]001 [DW_TAG_compile_unit]        11  {Fake} "
-      "Top\n"
+      "                                                     {InputFile} \"In.o\"\n\n"
+      "                                                     {Source} \"foo.cpp\"\n"
+      "[0x00001234][0x00000000]0 [DW_TAG_compile_unit]        11  {Fake} Top\n"
+      "                                                             - Attr\n"
+      "[0x00000011][0x00001234]1 [DW_TAG_namespace]          111    {Fake} Child1\n"
       "                                                               - Attr\n"
-      "[0x00000011][0x00001234]002 [DW_TAG_namespace]          111    {Fake} "
-      "Child1\n"
-      "                                                                 - "
-      "Attr\n"
-      "[0x11111111][0x00001234]222 [DW_TAG_enumeration_type]  1122    {Fake} "
-      "Child2\n"
-      "                                                                 - "
-      "Attr\n");
+      "[0x11111111][0x00001234]1 [DW_TAG_enumeration_type]  1122    {Fake} Child2\n"
+      "                                                               - Attr\n");
+  // clang-format on
   EXPECT_EQ(Output.str(), Expected);
 }
 
@@ -416,11 +407,6 @@ TEST(ScopeTextPrinter, PrintFlagAttributes) {
   Top->addObject(Child1);
   Top->addObject(Child2);
   Top->addObject(Child3);
-
-  Top->setLevel(1);
-  Child1->setLevel(2);
-  Child2->setLevel(2);
-  Child3->setLevel(2);
 
   Child1->setIsGlobalReference();
   Child3->setIsGlobalReference();
@@ -446,13 +432,13 @@ TEST(ScopeTextPrinter, PrintFlagAttributes) {
   ScopeTextPrinter(Settings, "In.o").print(&Root, Output);
   EXPECT_EQ(Output.str(), "      {InputFile} \"In.o\"\n\n"
                           "      {Source} \"foo.cpp\"\n"
-                          "1       1  {Fake} Top\n"
+                          "0       1  {Fake} Top\n"
                           "             - Attr\n"
-                          "2   X 111    {Fake} Child1\n"
+                          "1   X 111    {Fake} Child1\n"
                           "               - Attr\n"
-                          "2     222    {Fake} Child2\n"
+                          "1     222    {Fake} Child2\n"
                           "               - Attr\n"
-                          "2   X 333    {Fake} Child3\n"
+                          "1   X 333    {Fake} Child3\n"
                           "               - Attr\n");
 }
 
@@ -469,10 +455,6 @@ TEST(ScopeTextPrinter, PrintNoIndent) {
   Top->addObject(Child1);
   Child1->addObject(Child2);
 
-  Top->setLevel(1);
-  Child1->setLevel(2);
-  Child2->setLevel(3);
-
   Child1->setIsGlobalReference();
 
   std::stringstream Output;
@@ -484,11 +466,11 @@ TEST(ScopeTextPrinter, PrintNoIndent) {
   ScopeTextPrinter(Settings, "In.o").print(&Root, Output);
   EXPECT_EQ(Output.str(), "      {InputFile} \"In.o\"\n\n"
                           "      {Source} \"foo.cpp\"\n"
-                          "1       1  {Fake} Top\n"
+                          "0       1  {Fake} Top\n"
                           "             - Attr\n"
-                          "2   X 111    {Fake} Child1\n"
+                          "1   X 111    {Fake} Child1\n"
                           "               - Attr\n"
-                          "3     222      {Fake} Child2\n"
+                          "2     222      {Fake} Child2\n"
                           "                 - Attr\n");
 
   Output.str("");
@@ -496,10 +478,10 @@ TEST(ScopeTextPrinter, PrintNoIndent) {
   ScopeTextPrinter(Settings, "In.o").print(&Root, Output);
   EXPECT_EQ(Output.str(), "      {InputFile} \"In.o\"\n\n"
                           "      {Source} \"foo.cpp\"\n"
-                          "1       1  {Fake} Top\n"
+                          "0       1  {Fake} Top\n"
                           "             - Attr\n"
-                          "2   X 111  {Fake} Child1\n"
+                          "1   X 111  {Fake} Child1\n"
                           "             - Attr\n"
-                          "3     222  {Fake} Child2\n"
+                          "2     222  {Fake} Child2\n"
                           "             - Attr\n");
 }

--- a/DIVA/UnitTests/src/TestLibScopeView/TestSymbol.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestSymbol.cpp
@@ -142,7 +142,7 @@ TEST(Symbol, getAsYAML_Member) {
 TEST(Symbol, getAsText_Parameter) {
   PrintSettings Settings;
 
-  Symbol Sym(0);
+  Symbol Sym;
   Sym.setIsParameter();
   EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} -> \"void\"");
 
@@ -152,14 +152,14 @@ TEST(Symbol, getAsText_Parameter) {
   Sym.setName("qaz");
   EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} \"qaz\" -> \"\"");
 
-  Type Ty(0);
+  Type Ty;
   Ty.setIsBaseType();
   Ty.setName("wsx");
   Sym.setType(&Ty);
   EXPECT_EQ(Sym.getAsText(Settings), "{Parameter} \"qaz\" -> \"wsx\"");
 
   // Templates have the indicator reversed '<-'.
-  Scope Scp(0);
+  Scope Scp;
   Scp.setIsScope();
   Scp.setIsTemplate();
   Sym.setParent(&Scp);

--- a/DIVA/UnitTests/src/TestLibScopeView/TestType.cpp
+++ b/DIVA/UnitTests/src/TestLibScopeView/TestType.cpp
@@ -98,7 +98,7 @@ TEST(Type, getAsText_Param) {
   Ty.setName("wsx");
 
   // Template type.
-  TypeParam TyParam(0);
+  TypeParam TyParam;
   TyParam.setIsType();
   TyParam.setIncludeInPrint();
   TyParam.setName("qaz");
@@ -134,7 +134,7 @@ TEST(Type, getAsText_Param) {
             "{TemplateParameter} \"TTemp\" <- \"vector\"");
 
   // Template packs print differently.
-  Scope ScpTP(0);
+  Scope ScpTP;
   ScpTP.setIsScope();
   ScpTP.setIsTemplatePack();
   TyParam.setParent(&ScpTP);
@@ -233,7 +233,7 @@ TEST(Type, getAsYAML_Param) {
 TEST(Type, getAsText_PrimitiveType) {
   PrintSettings Settings;
 
-  Type Ty(/*level*/ 3);
+  Type Ty;
   Ty.setIsBaseType();
   Ty.setIncludeInPrint();
 
@@ -277,7 +277,7 @@ TEST(Type, getAsYAML_PrimitiveType) {
 TEST(Type, getAsText_Typedef) {
   PrintSettings Settings;
 
-  TypeDefinition TyDef(0);
+  TypeDefinition TyDef;
   ASSERT_TRUE(TyDef.getIsPrintedAsObject());
   TyDef.setIsTypedef();
   TyDef.setIncludeInPrint();
@@ -287,7 +287,7 @@ TEST(Type, getAsText_Typedef) {
   TyDef.setName("qaz");
   EXPECT_EQ(TyDef.getAsText(Settings), "{Alias} \"qaz\" -> \"\"");
 
-  TypeDefinition TyDef2(0);
+  TypeDefinition TyDef2;
   TyDef2.setIsTypedef();
   TyDef2.setIncludeInPrint();
   TyDef2.setName("wsx");
@@ -296,7 +296,7 @@ TEST(Type, getAsText_Typedef) {
 }
 
 TEST(Type, getAsYAML_Typedef) {
-  TypeDefinition TD(0);
+  TypeDefinition TD;
   TD.setIsTypedef();
   TD.setDieOffset(0x84);
   TD.setDieTag(DW_TAG_typedef);
@@ -322,13 +322,13 @@ TEST(Type, getAsYAML_Typedef) {
 TEST(Type, getAsText_Using) {
   PrintSettings Settings;
 
-  Scope CU(0);
+  Scope CU;
   CU.setIsCompileUnit();
   CU.setName("I should never be seen!");
 
   TypeImport UsingNamespace;
   UsingNamespace.setIsImportedModule();
-  Scope NS(0);
+  Scope NS;
   NS.setName("test_name");
   NS.setParent(&CU);
   UsingNamespace.setType(&NS);
@@ -337,13 +337,13 @@ TEST(Type, getAsText_Using) {
 
   TypeImport UsingType;
   UsingType.setIsImportedDeclaration();
-  Type Ty(0);
+  Type Ty;
   Ty.setName("test_type");
   Ty.setParent(&CU);
   UsingType.setType(&Ty);
   EXPECT_EQ(UsingType.getAsText(Settings), "{Using} type \"test_type\"");
 
-  Scope Parent(0);
+  Scope Parent;
   Parent.setName("parent");
   Ty.setParent(&Parent);
   EXPECT_EQ(UsingType.getAsText(Settings),
@@ -351,7 +351,7 @@ TEST(Type, getAsText_Using) {
 
   TypeImport UsingVariable;
   UsingVariable.setIsImportedDeclaration();
-  Symbol Variable(0);
+  Symbol Variable;
   Variable.setIsVariable();
   Variable.setName("test_variable");
   Variable.setParent(&CU);
@@ -365,7 +365,7 @@ TEST(Type, getAsText_Using) {
 
   TypeImport UsingMember;
   UsingMember.setIsImportedDeclaration();
-  Symbol Member(0);
+  Symbol Member;
   Member.setIsMember();
   Member.setName("test_member");
   Member.setParent(&CU);
@@ -379,7 +379,7 @@ TEST(Type, getAsText_Using) {
 
   TypeImport UsingFunction;
   UsingFunction.setIsImportedDeclaration();
-  Scope Func(0);
+  Scope Func;
   Func.setIsFunction();
   Func.setName("test_function");
   Func.setParent(&CU);
@@ -393,7 +393,7 @@ TEST(Type, getAsText_Using) {
 
   TypeImport UsingStruct;
   UsingStruct.setIsImportedDeclaration();
-  Scope ScpStruct(0);
+  Scope ScpStruct;
   ScpStruct.setIsStructType();
   ScpStruct.setName("test_struct");
   ScpStruct.setParent(&CU);
@@ -405,7 +405,7 @@ TEST(Type, getAsText_Using) {
             "{Using} type \"parent::test_struct\"");
 
   // What if we have nested parents?
-  Scope GrandParent(0);
+  Scope GrandParent;
   GrandParent.setName("grandparent");
   Parent.setParent(&GrandParent);
   EXPECT_EQ(UsingFunction.getAsText(Settings),
@@ -413,7 +413,7 @@ TEST(Type, getAsText_Using) {
 }
 
 TEST(Type, getAsYAML_Using) {
-  Scope CU(0);
+  Scope CU;
   CU.setIsCompileUnit();
   CU.setName("I should never be seen!");
 
@@ -423,7 +423,7 @@ TEST(Type, getAsYAML_Using) {
   UsingNamespace.setFileName("test_file.cpp");
   UsingNamespace.setDieTag(DW_TAG_imported_module);
   UsingNamespace.setDieOffset(0xdeadb33f);
-  Scope NS(0);
+  Scope NS;
   NS.setName("test_name");
   NS.setParent(&CU);
   UsingNamespace.setType(&NS);
@@ -445,7 +445,7 @@ TEST(Type, getAsYAML_Using) {
   UsingType.setFileName("test_file.cpp");
   UsingType.setDieTag(DW_TAG_imported_declaration);
   UsingType.setDieOffset(0xdeadb33f);
-  Type Ty(0);
+  Type Ty;
   Ty.setName("test_type");
   Ty.setParent(&CU);
   UsingType.setType(&Ty);
@@ -461,7 +461,7 @@ TEST(Type, getAsYAML_Using) {
                                    "\nattributes:"
                                    "\n  using_type: \"type\"");
 
-  Scope Parent(0);
+  Scope Parent;
   Parent.setName("parent");
   Ty.setParent(&Parent);
   EXPECT_EQ(UsingType.getAsYAML(), "object: \"Using\""
@@ -482,7 +482,7 @@ TEST(Type, getAsYAML_Using) {
   UsingVariable.setFileName("test_file.cpp");
   UsingVariable.setDieTag(DW_TAG_imported_declaration);
   UsingVariable.setDieOffset(0xdeadb33f);
-  Symbol Variable(0);
+  Symbol Variable;
   Variable.setIsVariable();
   Variable.setName("test_variable");
   Variable.setParent(&CU);
@@ -520,7 +520,7 @@ TEST(Type, getAsYAML_Using) {
   UsingMember.setFileName("test_file.cpp");
   UsingMember.setDieTag(DW_TAG_imported_declaration);
   UsingMember.setDieOffset(0xdeadb33f);
-  Symbol Member(0);
+  Symbol Member;
   Member.setIsMember();
   Member.setName("test_member");
   Member.setParent(&CU);
@@ -556,7 +556,7 @@ TEST(Type, getAsYAML_Using) {
   UsingFunction.setFileName("test_file.cpp");
   UsingFunction.setDieTag(DW_TAG_imported_declaration);
   UsingFunction.setDieOffset(0xdeadb33f);
-  Scope Function(0);
+  Scope Function;
   Function.setIsFunction();
   Function.setName("test_function");
   Function.setParent(&CU);
@@ -594,7 +594,7 @@ TEST(Type, getAsYAML_Using) {
   UsingStruct.setFileName("test_file.cpp");
   UsingStruct.setDieTag(DW_TAG_imported_declaration);
   UsingStruct.setDieOffset(0xdeadb33f);
-  Scope StructType(0);
+  Scope StructType;
   StructType.setIsStructType();
   StructType.setName("test_struct");
   StructType.setParent(&CU);
@@ -625,7 +625,7 @@ TEST(Type, getAsYAML_Using) {
                                      "\n  using_type: \"type\"");
 
   // Test nested parents.
-  Scope Grandparent(0);
+  Scope Grandparent;
   Grandparent.setName("grandparent");
   Parent.setParent(&Grandparent);
   EXPECT_EQ(UsingFunction.getAsYAML(), "object: \"Using\""


### PR DESCRIPTION
Save some space on each Object by not storing the Object's level, and then keeping track of it when traversing if required.