### PR TITLE
Report that DIVA has merged into llvm

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 DIVA is a command line tool that processes DWARF debug information contained within ELF files and prints the semantics of that debug information. The DIVA output is designed to be understandable by software programmers without any low-level compiler or DWARF knowledge; as such, it can be used to report debug information bugs to the compiler provider. DIVA's output can also be used as the input to DWARF tests, to compare the debug information generated from multiple compilers, from different versions of the same compiler, from different compiler switches and from the use of different DWARF specifications (i.e. DWARF 3, 4 and 5). DIVA will be used on the LLVM project to test and validate the output of clang to help improve the quality of the debug experience.
 
+# DIVA has been merged into LLVM!
+
+We've re-named DIVA to llvm-debuginfo-analyzer and merged it into the LLVM monorepo, to be found [here](https://github.com/llvm/llvm-project). The tooling can be found under llvm/tools/llvm-debuginfo-analyzer, while most of the plumbing is in llvm/lib/DebugInfo/LogicalView. Development continues in the llvm monorepo.
+
 ## User Guide
 
 For instructions on using DIVA please refer to the [user guide](./DIVA/Documentation/user_guide.md).


### PR DESCRIPTION
Seeing how we've upstream'd DIVA into the LLVM monorepo, we'll eventually archive this git repo: insert a paragraph about where development has gone in preparation for that archiving.